### PR TITLE
Adding DCCM Protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-!scripts/
-!scripts/template_metad/*
+scripts/dccm_test_2/
+scripts/dccm_test/

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/1hel.pdb
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/1hel.pdb
@@ -1,0 +1,1528 @@
+HEADER    HYDROLASE(O-GLYCOSYL)                   10-JAN-92   1HEL              
+TITLE     STRUCTURAL AND THERMODYNAMIC ANALYSIS OF COMPENSATING MUTATIONS WITHIN
+TITLE    2 THE CORE OF CHICKEN EGG WHITE LYSOZYME                               
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: HEN EGG WHITE LYSOZYME;                                    
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 EC: 3.2.1.17;                                                        
+COMPND   5 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: GALLUS GALLUS;                                  
+SOURCE   3 ORGANISM_COMMON: CHICKEN;                                            
+SOURCE   4 ORGANISM_TAXID: 9031;                                                
+SOURCE   5 ORGAN: EGG                                                           
+KEYWDS    HYDROLASE(O-GLYCOSYL)                                                 
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    K.P.WILSON,B.A.MALCOLM,B.W.MATTHEWS                                   
+REVDAT   5   30-JUN-21 1HEL    1       REMARK                                   
+REVDAT   4   22-JUL-20 1HEL    1       REMARK ATOM                              
+REVDAT   3   16-NOV-11 1HEL    1       VERSN  HETATM                            
+REVDAT   2   24-FEB-09 1HEL    1       VERSN                                    
+REVDAT   1   31-OCT-93 1HEL    0                                                
+JRNL        AUTH   K.P.WILSON,B.A.MALCOLM,B.W.MATTHEWS                          
+JRNL        TITL   STRUCTURAL AND THERMODYNAMIC ANALYSIS OF COMPENSATING        
+JRNL        TITL 2 MUTATIONS WITHIN THE CORE OF CHICKEN EGG WHITE LYSOZYME.     
+JRNL        REF    J.BIOL.CHEM.                  V. 267 10842 1992              
+JRNL        REFN                   ISSN 0021-9258                               
+JRNL        PMID   1587860                                                      
+REMARK   1                                                                      
+REMARK   1 REFERENCE 1                                                          
+REMARK   1  AUTH   B.A.MALCOLM,K.P.WILSON,B.W.MATTHEWS,J.F.KIRSCH,A.C.WILSON    
+REMARK   1  TITL   ANCESTRAL LYSOZYMES RECONSTRUCTED, NEUTRALITY TESTED, AND    
+REMARK   1  TITL 2 THERMOSTABILITY LINKED TO HYDROCARBON PACKING                
+REMARK   1  REF    NATURE                        V. 344    86 1990              
+REMARK   1  REFN                   ISSN 0028-0836                               
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    1.70 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : TNT                                                  
+REMARK   3   AUTHORS     : TRONRUD,TEN EYCK,MATTHEWS                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 1.70                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : NULL                           
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : NULL                           
+REMARK   3   COMPLETENESS FOR RANGE        (%) : NULL                           
+REMARK   3   NUMBER OF REFLECTIONS             : NULL                           
+REMARK   3                                                                      
+REMARK   3  USING DATA ABOVE SIGMA CUTOFF.                                      
+REMARK   3   CROSS-VALIDATION METHOD          : NULL                            
+REMARK   3   FREE R VALUE TEST SET SELECTION  : NULL                            
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.152                           
+REMARK   3   R VALUE            (WORKING SET) : NULL                            
+REMARK   3   FREE R VALUE                     : NULL                            
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : NULL                            
+REMARK   3   FREE R VALUE TEST SET COUNT      : NULL                            
+REMARK   3                                                                      
+REMARK   3  USING ALL DATA, NO SIGMA CUTOFF.                                    
+REMARK   3   R VALUE   (WORKING + TEST SET, NO CUTOFF) : NULL                   
+REMARK   3   R VALUE          (WORKING SET, NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE                  (NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE TEST SET SIZE (%, NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE TEST SET COUNT   (NO CUTOFF) : NULL                   
+REMARK   3   TOTAL NUMBER OF REFLECTIONS   (NO CUTOFF) : NULL                   
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 1001                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 0                                       
+REMARK   3   SOLVENT ATOMS            : 185                                     
+REMARK   3                                                                      
+REMARK   3  WILSON B VALUE (FROM FCALC, A**2) : NULL                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.    RMS    WEIGHT  COUNT           
+REMARK   3   BOND LENGTHS                 (A) : 0.019 ; NULL  ; NULL            
+REMARK   3   BOND ANGLES            (DEGREES) : 2.400 ; NULL  ; NULL            
+REMARK   3   TORSION ANGLES         (DEGREES) : NULL  ; NULL  ; NULL            
+REMARK   3   PSEUDOROTATION ANGLES  (DEGREES) : NULL  ; NULL  ; NULL            
+REMARK   3   TRIGONAL CARBON PLANES       (A) : NULL  ; NULL  ; NULL            
+REMARK   3   GENERAL PLANES               (A) : NULL  ; NULL  ; NULL            
+REMARK   3   ISOTROPIC THERMAL FACTORS (A**2) : NULL  ; NULL  ; NULL            
+REMARK   3   NON-BONDED CONTACTS          (A) : NULL  ; NULL  ; NULL            
+REMARK   3                                                                      
+REMARK   3  INCORRECT CHIRAL-CENTERS (COUNT) : NULL                             
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED : NULL                                                 
+REMARK   3   KSOL        : NULL                                                 
+REMARK   3   BSOL        : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  RESTRAINT LIBRARIES.                                                
+REMARK   3   STEREOCHEMISTRY : NULL                                             
+REMARK   3   ISOTROPIC THERMAL FACTOR RESTRAINTS : NULL                         
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1HEL COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
+REMARK 100 THE DEPOSITION ID IS D_1000173812.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : NULL                               
+REMARK 200  TEMPERATURE           (KELVIN) : 298                                
+REMARK 200  PH                             : NULL                               
+REMARK 200  NUMBER OF CRYSTALS USED        : NULL                               
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : N                                  
+REMARK 200  RADIATION SOURCE               : ROTATING ANODE                     
+REMARK 200  BEAMLINE                       : NULL                               
+REMARK 200  X-RAY GENERATOR MODEL          : ELLIOTT GX-21                      
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : NULL                               
+REMARK 200  MONOCHROMATOR                  : GRAPHITE                           
+REMARK 200  OPTICS                         : KODAK NO-SCREEN X-RAY FILM         
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : FILM                               
+REMARK 200  DETECTOR MANUFACTURER          : OSCILLATION CAMERA                 
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : NULL                               
+REMARK 200  DATA SCALING SOFTWARE          : AGROVATA / ROTAVATA                
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : NULL                               
+REMARK 200  RESOLUTION RANGE HIGH      (A) : NULL                               
+REMARK 200  RESOLUTION RANGE LOW       (A) : NULL                               
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : NULL                               
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY                : NULL                               
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : NULL                               
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : NULL                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : NULL                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: NULL                         
+REMARK 200 SOFTWARE USED: NULL                                                  
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 40.52                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.07                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: NULL                                     
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 43 21 2                        
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,-Y,Z+1/2                                             
+REMARK 290       3555   -Y+1/2,X+1/2,Z+3/4                                      
+REMARK 290       4555   Y+1/2,-X+1/2,Z+1/4                                      
+REMARK 290       5555   -X+1/2,Y+1/2,-Z+3/4                                     
+REMARK 290       6555   X+1/2,-Y+1/2,-Z+1/4                                     
+REMARK 290       7555   Y,X,-Z                                                  
+REMARK 290       8555   -Y,-X,-Z+1/2                                            
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       18.95000            
+REMARK 290   SMTRY1   3  0.000000 -1.000000  0.000000       39.55000            
+REMARK 290   SMTRY2   3  1.000000  0.000000  0.000000       39.55000            
+REMARK 290   SMTRY3   3  0.000000  0.000000  1.000000       28.42500            
+REMARK 290   SMTRY1   4  0.000000  1.000000  0.000000       39.55000            
+REMARK 290   SMTRY2   4 -1.000000  0.000000  0.000000       39.55000            
+REMARK 290   SMTRY3   4  0.000000  0.000000  1.000000        9.47500            
+REMARK 290   SMTRY1   5 -1.000000  0.000000  0.000000       39.55000            
+REMARK 290   SMTRY2   5  0.000000  1.000000  0.000000       39.55000            
+REMARK 290   SMTRY3   5  0.000000  0.000000 -1.000000       28.42500            
+REMARK 290   SMTRY1   6  1.000000  0.000000  0.000000       39.55000            
+REMARK 290   SMTRY2   6  0.000000 -1.000000  0.000000       39.55000            
+REMARK 290   SMTRY3   6  0.000000  0.000000 -1.000000        9.47500            
+REMARK 290   SMTRY1   7  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   7  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   7  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   8  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   8 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   8  0.000000  0.000000 -1.000000       18.95000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 375                                                                      
+REMARK 375 SPECIAL POSITION                                                     
+REMARK 375 THE FOLLOWING ATOMS ARE FOUND TO BE WITHIN 0.15 ANGSTROMS            
+REMARK 375 OF A SYMMETRY RELATED ATOM AND ARE ASSUMED TO BE ON SPECIAL          
+REMARK 375 POSITIONS.                                                           
+REMARK 375                                                                      
+REMARK 375 ATOM RES CSSEQI                                                      
+REMARK 375      HOH A 318  LIES ON A SPECIAL POSITION.                          
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS                                             
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS THAT ARE RELATED BY CRYSTALLOGRAPHIC             
+REMARK 500 SYMMETRY ARE IN CLOSE CONTACT.  AN ATOM LOCATED WITHIN 0.15          
+REMARK 500 ANGSTROMS OF A SYMMETRY RELATED ATOM IS ASSUMED TO BE ON A           
+REMARK 500 SPECIAL POSITION AND IS, THEREFORE, LISTED IN REMARK 375             
+REMARK 500 INSTEAD OF REMARK 500.  ATOMS WITH NON-BLANK ALTERNATE               
+REMARK 500 LOCATION INDICATORS ARE NOT INCLUDED IN THE CALCULATIONS.            
+REMARK 500                                                                      
+REMARK 500 DISTANCE CUTOFF:                                                     
+REMARK 500 2.2 ANGSTROMS FOR CONTACTS NOT INVOLVING HYDROGEN ATOMS              
+REMARK 500 1.6 ANGSTROMS FOR CONTACTS INVOLVING HYDROGEN ATOMS                  
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI  SSYMOP   DISTANCE          
+REMARK 500   O    HOH A   203     O    HOH A   203     7556     1.38            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    ARG A   5   NE  -  CZ  -  NH1 ANGL. DEV. =   4.8 DEGREES          
+REMARK 500    ARG A  14   NE  -  CZ  -  NH1 ANGL. DEV. =   3.2 DEGREES          
+REMARK 500    ASP A  18   CB  -  CG  -  OD1 ANGL. DEV. =   8.7 DEGREES          
+REMARK 500    ASP A  18   CB  -  CG  -  OD2 ANGL. DEV. =  -8.1 DEGREES          
+REMARK 500    ARG A  45   NE  -  CZ  -  NH1 ANGL. DEV. =   3.4 DEGREES          
+REMARK 500    ASP A  52   CB  -  CG  -  OD1 ANGL. DEV. =   5.5 DEGREES          
+REMARK 500    ARG A  61   NE  -  CZ  -  NH1 ANGL. DEV. =   3.6 DEGREES          
+REMARK 500    PRO A  70   C   -  N   -  CA  ANGL. DEV. =  10.0 DEGREES          
+REMARK 500    PRO A  70   C   -  N   -  CD  ANGL. DEV. = -13.8 DEGREES          
+REMARK 500    ARG A  73   NE  -  CZ  -  NH1 ANGL. DEV. =   3.3 DEGREES          
+REMARK 500    ASP A  87   CB  -  CG  -  OD1 ANGL. DEV. =   5.6 DEGREES          
+REMARK 500    ASP A 119   CB  -  CG  -  OD2 ANGL. DEV. =  -5.6 DEGREES          
+REMARK 500    ARG A 128   NE  -  CZ  -  NH1 ANGL. DEV. =   3.7 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ARG A  68       19.50   -141.12                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+DBREF  1HEL A    1   129  UNP    P00698   LYSC_CHICK      19    147             
+SEQRES   1 A  129  LYS VAL PHE GLY ARG CYS GLU LEU ALA ALA ALA MET LYS          
+SEQRES   2 A  129  ARG HIS GLY LEU ASP ASN TYR ARG GLY TYR SER LEU GLY          
+SEQRES   3 A  129  ASN TRP VAL CYS ALA ALA LYS PHE GLU SER ASN PHE ASN          
+SEQRES   4 A  129  THR GLN ALA THR ASN ARG ASN THR ASP GLY SER THR ASP          
+SEQRES   5 A  129  TYR GLY ILE LEU GLN ILE ASN SER ARG TRP TRP CYS ASN          
+SEQRES   6 A  129  ASP GLY ARG THR PRO GLY SER ARG ASN LEU CYS ASN ILE          
+SEQRES   7 A  129  PRO CYS SER ALA LEU LEU SER SER ASP ILE THR ALA SER          
+SEQRES   8 A  129  VAL ASN CYS ALA LYS LYS ILE VAL SER ASP GLY ASN GLY          
+SEQRES   9 A  129  MET ASN ALA TRP VAL ALA TRP ARG ASN ARG CYS LYS GLY          
+SEQRES  10 A  129  THR ASP VAL GLN ALA TRP ILE ARG GLY CYS ARG LEU              
+FORMUL   2  HOH   *185(H2 O)                                                    
+HELIX    1  H1 GLY A    4  GLY A   16  1                                  13    
+HELIX    2  H2 LEU A   25  PHE A   34  1                                  10    
+HELIX    3  H3 PRO A   79  LEU A   84  5                                   6    
+HELIX    4  H4 ILE A   88  SER A  100  1                                  13    
+HELIX    5  H5 GLY A  104  TRP A  108  5                                   5    
+HELIX    6  H6 VAL A  109  ARG A  114  1                                   6    
+HELIX    7  H7 VAL A  120  ILE A  124  5                                   5    
+SHEET    1  S1 3 ALA A  42  ASN A  46  0                                        
+SHEET    2  S1 3 GLY A  49  GLY A  54 -1  O  SER A  50   N  ASN A  46           
+SHEET    3  S1 3 LEU A  56  SER A  60 -1  O  SER A  60   N  THR A  51           
+SSBOND   1 CYS A    6    CYS A  127                          1555   1555  1.99  
+SSBOND   2 CYS A   30    CYS A  115                          1555   1555  2.11  
+SSBOND   3 CYS A   64    CYS A   80                          1555   1555  2.00  
+SSBOND   4 CYS A   76    CYS A   94                          1555   1555  2.10  
+CRYST1   79.100   79.100   37.900  90.00  90.00  90.00 P 43 21 2     8          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.012642  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.012642  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.026385        0.00000                         
+ATOM      1  N   LYS A   1       3.294  10.164  10.266  1.00 11.18           N  
+ATOM      2  CA  LYS A   1       2.388  10.533   9.168  1.00  9.68           C  
+ATOM      3  C   LYS A   1       2.438  12.049   8.889  1.00 14.00           C  
+ATOM      4  O   LYS A   1       2.406  12.898   9.815  1.00 14.00           O  
+ATOM      5  CB  LYS A   1       0.949  10.101   9.559  1.00 13.29           C  
+ATOM      6  CG  LYS A   1      -0.050  10.621   8.573  1.00 13.52           C  
+ATOM      7  CD  LYS A   1      -1.425  10.081   8.720  1.00 22.15           C  
+ATOM      8  CE  LYS A   1      -2.370  10.773   7.722  1.00 20.23           C  
+ATOM      9  NZ  LYS A   1      -3.776  10.439   7.933  1.00 68.72           N  
+ATOM     10  N   VAL A   2       2.552  12.428   7.626  1.00 10.17           N  
+ATOM     11  CA  VAL A   2       2.524  13.840   7.282  1.00 10.02           C  
+ATOM     12  C   VAL A   2       1.120  14.180   6.770  1.00 27.84           C  
+ATOM     13  O   VAL A   2       0.737  13.798   5.675  1.00 22.87           O  
+ATOM     14  CB  VAL A   2       3.529  14.264   6.240  1.00  9.00           C  
+ATOM     15  CG1 VAL A   2       3.313  15.765   5.983  1.00 11.37           C  
+ATOM     16  CG2 VAL A   2       4.928  14.016   6.810  1.00 10.57           C  
+ATOM     17  N   PHE A   3       0.333  14.851   7.573  1.00 16.35           N  
+ATOM     18  CA  PHE A   3      -1.021  15.173   7.169  1.00 15.34           C  
+ATOM     19  C   PHE A   3      -1.097  16.285   6.126  1.00 14.79           C  
+ATOM     20  O   PHE A   3      -0.261  17.203   6.054  1.00 14.99           O  
+ATOM     21  CB  PHE A   3      -1.867  15.710   8.361  1.00 14.03           C  
+ATOM     22  CG  PHE A   3      -2.412  14.638   9.295  1.00 16.41           C  
+ATOM     23  CD1 PHE A   3      -1.575  14.049  10.240  1.00 14.44           C  
+ATOM     24  CD2 PHE A   3      -3.757  14.285   9.274  1.00 18.12           C  
+ATOM     25  CE1 PHE A   3      -2.065  13.116  11.135  1.00 11.11           C  
+ATOM     26  CE2 PHE A   3      -4.263  13.332  10.178  1.00 32.24           C  
+ATOM     27  CZ  PHE A   3      -3.413  12.758  11.132  1.00 14.31           C  
+ATOM     28  N   GLY A   4      -2.229  16.228   5.393  1.00 15.47           N  
+ATOM     29  CA  GLY A   4      -2.645  17.273   4.511  1.00 13.97           C  
+ATOM     30  C   GLY A   4      -3.456  18.261   5.350  1.00 10.95           C  
+ATOM     31  O   GLY A   4      -4.070  17.876   6.282  1.00 16.45           O  
+ATOM     32  N   ARG A   5      -3.414  19.518   5.009  1.00 14.28           N  
+ATOM     33  CA  ARG A   5      -4.106  20.560   5.674  1.00 11.63           C  
+ATOM     34  C   ARG A   5      -5.540  20.226   5.992  1.00 21.37           C  
+ATOM     35  O   ARG A   5      -5.963  20.258   7.138  1.00  9.74           O  
+ATOM     36  CB  ARG A   5      -3.952  21.857   4.900  1.00 13.31           C  
+ATOM     37  CG  ARG A   5      -4.508  23.053   5.610  1.00 13.02           C  
+ATOM     38  CD  ARG A   5      -4.414  24.335   4.775  1.00 19.72           C  
+ATOM     39  NE  ARG A   5      -5.013  24.223   3.447  1.00 23.52           N  
+ATOM     40  CZ  ARG A   5      -6.287  24.522   3.048  1.00 40.17           C  
+ATOM     41  NH1 ARG A   5      -7.248  25.009   3.841  1.00 17.54           N  
+ATOM     42  NH2 ARG A   5      -6.619  24.303   1.767  1.00 33.21           N  
+ATOM     43  N   CYS A   6      -6.327  19.866   4.967  1.00 15.04           N  
+ATOM     44  CA  CYS A   6      -7.767  19.572   5.189  1.00 12.93           C  
+ATOM     45  C   CYS A   6      -7.997  18.269   5.916  1.00  5.10           C  
+ATOM     46  O   CYS A   6      -8.992  18.125   6.630  1.00 13.60           O  
+ATOM     47  CB  CYS A   6      -8.607  19.637   3.859  1.00 16.72           C  
+ATOM     48  SG  CYS A   6      -8.669  21.273   3.104  1.00 16.68           S  
+ATOM     49  N   GLU A   7      -7.142  17.274   5.653  1.00  7.34           N  
+ATOM     50  CA  GLU A   7      -7.309  15.981   6.323  1.00 10.86           C  
+ATOM     51  C   GLU A   7      -7.129  16.181   7.848  1.00 17.71           C  
+ATOM     52  O   GLU A   7      -7.835  15.638   8.657  1.00 14.19           O  
+ATOM     53  CB  GLU A   7      -6.187  15.048   5.880  1.00 16.19           C  
+ATOM     54  CG  GLU A   7      -6.206  13.614   6.496  1.00 16.67           C  
+ATOM     55  CD  GLU A   7      -4.952  12.864   6.030  1.00 32.91           C  
+ATOM     56  OE1 GLU A   7      -4.003  13.411   5.480  1.00 18.18           O  
+ATOM     57  OE2 GLU A   7      -4.992  11.578   6.219  1.00 28.07           O  
+ATOM     58  N   LEU A   8      -6.148  16.987   8.221  1.00 14.04           N  
+ATOM     59  CA  LEU A   8      -5.919  17.285   9.637  1.00  8.65           C  
+ATOM     60  C   LEU A   8      -7.068  18.103  10.254  1.00 10.08           C  
+ATOM     61  O   LEU A   8      -7.500  17.827  11.353  1.00 15.66           O  
+ATOM     62  CB  LEU A   8      -4.607  18.084   9.809  1.00 14.88           C  
+ATOM     63  CG  LEU A   8      -4.384  18.432  11.299  1.00 12.61           C  
+ATOM     64  CD1 LEU A   8      -4.110  17.104  12.053  1.00 12.51           C  
+ATOM     65  CD2 LEU A   8      -3.147  19.299  11.372  1.00 13.98           C  
+ATOM     66  N   ALA A   9      -7.524  19.122   9.561  1.00 11.92           N  
+ATOM     67  CA  ALA A   9      -8.664  19.896   9.982  1.00 10.97           C  
+ATOM     68  C   ALA A   9      -9.841  18.971  10.304  1.00 15.73           C  
+ATOM     69  O   ALA A   9     -10.469  19.046  11.359  1.00 13.41           O  
+ATOM     70  CB  ALA A   9      -9.039  21.012   8.954  1.00  8.88           C  
+ATOM     71  N   ALA A  10     -10.124  18.049   9.425  1.00 12.11           N  
+ATOM     72  CA  ALA A  10     -11.262  17.129   9.595  1.00 12.19           C  
+ATOM     73  C   ALA A  10     -11.034  16.206  10.780  1.00 18.02           C  
+ATOM     74  O   ALA A  10     -11.932  15.902  11.522  1.00 17.70           O  
+ATOM     75  CB  ALA A  10     -11.457  16.297   8.313  1.00 14.75           C  
+ATOM     76  N   ALA A  11      -9.815  15.771  10.988  1.00 14.94           N  
+ATOM     77  CA  ALA A  11      -9.544  14.908  12.136  1.00 12.19           C  
+ATOM     78  C   ALA A  11      -9.651  15.641  13.494  1.00  7.51           C  
+ATOM     79  O   ALA A  11     -10.088  15.066  14.457  1.00 12.99           O  
+ATOM     80  CB  ALA A  11      -8.153  14.250  12.041  1.00 15.76           C  
+ATOM     81  N   MET A  12      -9.107  16.884  13.529  1.00 10.71           N  
+ATOM     82  CA  MET A  12      -9.160  17.683  14.710  1.00 12.27           C  
+ATOM     83  C   MET A  12     -10.599  17.988  15.028  1.00 16.76           C  
+ATOM     84  O   MET A  12     -10.964  17.966  16.195  1.00 17.43           O  
+ATOM     85  CB  MET A  12      -8.385  18.996  14.563  1.00  6.96           C  
+ATOM     86  CG  MET A  12      -6.872  18.717  14.593  1.00  7.53           C  
+ATOM     87  SD  MET A  12      -5.971  20.286  14.351  1.00 16.25           S  
+ATOM     88  CE  MET A  12      -4.392  19.972  15.137  1.00 11.48           C  
+ATOM     89  N   LYS A  13     -11.421  18.239  13.985  1.00 11.66           N  
+ATOM     90  CA  LYS A  13     -12.844  18.554  14.146  1.00 12.77           C  
+ATOM     91  C   LYS A  13     -13.552  17.402  14.762  1.00 17.21           C  
+ATOM     92  O   LYS A  13     -14.278  17.533  15.704  1.00 15.75           O  
+ATOM     93  CB  LYS A  13     -13.505  18.908  12.852  1.00 14.38           C  
+ATOM     94  CG  LYS A  13     -14.874  19.457  13.096  1.00 16.88           C  
+ATOM     95  CD  LYS A  13     -15.519  20.062  11.867  1.00 19.73           C  
+ATOM     96  CE  LYS A  13     -17.062  20.060  11.971  1.00 41.06           C  
+ATOM     97  NZ  LYS A  13     -17.725  20.836  10.899  1.00 61.80           N  
+ATOM     98  N   ARG A  14     -13.273  16.240  14.220  1.00 21.68           N  
+ATOM     99  CA  ARG A  14     -13.878  15.021  14.667  1.00 17.17           C  
+ATOM    100  C   ARG A  14     -13.480  14.746  16.099  1.00 27.88           C  
+ATOM    101  O   ARG A  14     -14.217  14.129  16.823  1.00 17.70           O  
+ATOM    102  CB  ARG A  14     -13.448  13.876  13.756  1.00 23.48           C  
+ATOM    103  CG  ARG A  14     -14.102  12.553  14.162  1.00 51.76           C  
+ATOM    104  CD  ARG A  14     -13.875  11.424  13.160  1.00 52.15           C  
+ATOM    105  NE  ARG A  14     -12.616  10.730  13.354  1.00 61.79           N  
+ATOM    106  CZ  ARG A  14     -12.406   9.681  14.156  1.00 47.00           C  
+ATOM    107  NH1 ARG A  14     -13.357   9.121  14.898  1.00 35.04           N  
+ATOM    108  NH2 ARG A  14     -11.177   9.169  14.196  1.00 55.70           N  
+ATOM    109  N   HIS A  15     -12.300  15.219  16.498  1.00 20.13           N  
+ATOM    110  CA  HIS A  15     -11.791  15.016  17.846  1.00 14.58           C  
+ATOM    111  C   HIS A  15     -12.221  16.074  18.888  1.00 18.83           C  
+ATOM    112  O   HIS A  15     -11.689  16.060  19.970  1.00 22.76           O  
+ATOM    113  CB  HIS A  15     -10.268  14.799  17.851  1.00 23.09           C  
+ATOM    114  CG  HIS A  15      -9.906  13.364  17.563  1.00 21.53           C  
+ATOM    115  ND1 HIS A  15      -9.721  12.896  16.256  1.00 28.28           N  
+ATOM    116  CD2 HIS A  15      -9.723  12.308  18.413  1.00 30.99           C  
+ATOM    117  CE1 HIS A  15      -9.422  11.580  16.350  1.00 20.50           C  
+ATOM    118  NE2 HIS A  15      -9.412  11.213  17.627  1.00 42.34           N  
+ATOM    119  N   GLY A  16     -13.146  16.952  18.551  1.00 14.90           N  
+ATOM    120  CA  GLY A  16     -13.687  17.956  19.401  1.00 16.84           C  
+ATOM    121  C   GLY A  16     -12.871  19.227  19.554  1.00 23.06           C  
+ATOM    122  O   GLY A  16     -13.121  20.016  20.460  1.00 19.24           O  
+ATOM    123  N   LEU A  17     -11.922  19.491  18.685  1.00 14.25           N  
+ATOM    124  CA  LEU A  17     -11.134  20.695  18.826  1.00 10.83           C  
+ATOM    125  C   LEU A  17     -11.728  21.961  18.295  1.00 16.61           C  
+ATOM    126  O   LEU A  17     -11.276  23.016  18.657  1.00 18.63           O  
+ATOM    127  CB  LEU A  17      -9.749  20.538  18.218  1.00 14.80           C  
+ATOM    128  CG  LEU A  17      -8.792  19.745  19.031  1.00 19.84           C  
+ATOM    129  CD1 LEU A  17      -7.483  19.876  18.293  1.00 22.16           C  
+ATOM    130  CD2 LEU A  17      -8.675  20.282  20.474  1.00 15.82           C  
+ATOM    131  N   ASP A  18     -12.704  21.930  17.405  1.00 18.32           N  
+ATOM    132  CA  ASP A  18     -13.261  23.178  16.884  1.00 18.68           C  
+ATOM    133  C   ASP A  18     -13.986  23.912  17.979  1.00 19.05           C  
+ATOM    134  O   ASP A  18     -14.952  23.375  18.512  1.00 21.74           O  
+ATOM    135  CB  ASP A  18     -14.275  23.002  15.717  1.00 25.90           C  
+ATOM    136  CG  ASP A  18     -14.712  24.288  15.010  1.00 37.66           C  
+ATOM    137  OD1 ASP A  18     -14.134  25.393  15.038  1.00 26.98           O  
+ATOM    138  OD2 ASP A  18     -15.751  24.055  14.248  1.00 63.41           O  
+ATOM    139  N   ASN A  19     -13.542  25.130  18.229  1.00 12.22           N  
+ATOM    140  CA  ASN A  19     -14.046  26.010  19.253  1.00  9.99           C  
+ATOM    141  C   ASN A  19     -13.851  25.507  20.671  1.00 15.97           C  
+ATOM    142  O   ASN A  19     -14.534  25.975  21.595  1.00 18.10           O  
+ATOM    143  CB  ASN A  19     -15.518  26.259  19.032  1.00 20.32           C  
+ATOM    144  CG  ASN A  19     -15.706  27.052  17.774  1.00 40.03           C  
+ATOM    145  OD1 ASN A  19     -15.227  28.183  17.693  1.00 57.25           O  
+ATOM    146  ND2 ASN A  19     -16.402  26.456  16.811  1.00 40.09           N  
+ATOM    147  N   TYR A  20     -12.956  24.552  20.827  1.00 12.49           N  
+ATOM    148  CA  TYR A  20     -12.652  24.027  22.106  1.00  8.91           C  
+ATOM    149  C   TYR A  20     -12.037  25.159  22.929  1.00 19.06           C  
+ATOM    150  O   TYR A  20     -10.978  25.687  22.602  1.00 16.99           O  
+ATOM    151  CB  TYR A  20     -11.717  22.810  22.005  1.00 17.23           C  
+ATOM    152  CG  TYR A  20     -11.532  22.151  23.355  1.00 13.76           C  
+ATOM    153  CD1 TYR A  20     -12.444  21.206  23.832  1.00 17.40           C  
+ATOM    154  CD2 TYR A  20     -10.475  22.556  24.184  1.00 24.53           C  
+ATOM    155  CE1 TYR A  20     -12.311  20.657  25.111  1.00 20.84           C  
+ATOM    156  CE2 TYR A  20     -10.331  22.023  25.461  1.00 16.26           C  
+ATOM    157  CZ  TYR A  20     -11.259  21.078  25.922  1.00 35.41           C  
+ATOM    158  OH  TYR A  20     -11.104  20.560  27.183  1.00 29.68           O  
+ATOM    159  N   ARG A  21     -12.721  25.593  23.977  1.00 19.00           N  
+ATOM    160  CA  ARG A  21     -12.250  26.715  24.791  1.00 15.05           C  
+ATOM    161  C   ARG A  21     -12.264  27.987  24.017  1.00  8.63           C  
+ATOM    162  O   ARG A  21     -11.450  28.877  24.295  1.00 13.69           O  
+ATOM    163  CB  ARG A  21     -10.847  26.601  25.387  1.00 18.33           C  
+ATOM    164  CG  ARG A  21     -10.694  25.514  26.442  1.00 27.37           C  
+ATOM    165  CD  ARG A  21     -11.577  25.864  27.598  1.00 40.81           C  
+ATOM    166  NE  ARG A  21     -11.597  24.902  28.676  1.00 57.85           N  
+ATOM    167  CZ  ARG A  21     -11.253  25.330  29.884  1.00 97.15           C  
+ATOM    168  NH1 ARG A  21     -10.859  26.593  30.049  1.00 63.15           N  
+ATOM    169  NH2 ARG A  21     -11.283  24.508  30.937  1.00 68.08           N  
+ATOM    170  N   GLY A  22     -13.173  28.076  23.045  1.00 11.97           N  
+ATOM    171  CA  GLY A  22     -13.290  29.312  22.253  1.00 13.56           C  
+ATOM    172  C   GLY A  22     -12.276  29.499  21.125  1.00 15.57           C  
+ATOM    173  O   GLY A  22     -12.274  30.537  20.508  1.00 15.13           O  
+ATOM    174  N   TYR A  23     -11.414  28.511  20.863  1.00 17.25           N  
+ATOM    175  CA  TYR A  23     -10.419  28.584  19.787  1.00 12.17           C  
+ATOM    176  C   TYR A  23     -10.964  27.832  18.564  1.00  7.69           C  
+ATOM    177  O   TYR A  23     -11.097  26.573  18.581  1.00  8.57           O  
+ATOM    178  CB  TYR A  23      -9.059  27.910  20.217  1.00 11.16           C  
+ATOM    179  CG  TYR A  23      -8.358  28.702  21.299  1.00 14.01           C  
+ATOM    180  CD1 TYR A  23      -7.560  29.766  20.910  1.00 10.23           C  
+ATOM    181  CD2 TYR A  23      -8.534  28.427  22.652  1.00  6.77           C  
+ATOM    182  CE1 TYR A  23      -6.879  30.557  21.846  1.00  9.23           C  
+ATOM    183  CE2 TYR A  23      -7.907  29.219  23.612  1.00 10.96           C  
+ATOM    184  CZ  TYR A  23      -7.061  30.276  23.207  1.00 12.99           C  
+ATOM    185  OH  TYR A  23      -6.411  31.069  24.111  1.00 13.78           O  
+ATOM    186  N   SER A  24     -11.219  28.590  17.517  1.00 12.88           N  
+ATOM    187  CA  SER A  24     -11.730  28.032  16.253  1.00 14.99           C  
+ATOM    188  C   SER A  24     -10.726  27.075  15.616  1.00 20.42           C  
+ATOM    189  O   SER A  24      -9.487  27.191  15.841  1.00  9.73           O  
+ATOM    190  CB  SER A  24     -12.060  29.179  15.305  1.00  9.90           C  
+ATOM    191  OG  SER A  24     -10.830  29.750  14.853  1.00 17.68           O  
+ATOM    192  N   LEU A  25     -11.267  26.110  14.822  1.00 16.10           N  
+ATOM    193  CA  LEU A  25     -10.460  25.111  14.092  1.00 11.40           C  
+ATOM    194  C   LEU A  25      -9.205  25.683  13.438  1.00 11.44           C  
+ATOM    195  O   LEU A  25      -8.145  25.073  13.536  1.00 10.56           O  
+ATOM    196  CB  LEU A  25     -11.293  24.412  12.993  1.00 13.62           C  
+ATOM    197  CG  LEU A  25     -10.826  23.089  12.491  1.00 16.00           C  
+ATOM    198  CD1 LEU A  25     -10.359  22.212  13.644  1.00 15.17           C  
+ATOM    199  CD2 LEU A  25     -12.018  22.437  11.805  1.00 15.75           C  
+ATOM    200  N   GLY A  26      -9.311  26.836  12.758  1.00 10.18           N  
+ATOM    201  CA  GLY A  26      -8.169  27.388  12.084  1.00  7.13           C  
+ATOM    202  C   GLY A  26      -6.984  27.643  12.997  1.00  9.12           C  
+ATOM    203  O   GLY A  26      -5.854  27.610  12.555  1.00 12.61           O  
+ATOM    204  N   ASN A  27      -7.232  27.928  14.280  1.00 10.01           N  
+ATOM    205  CA  ASN A  27      -6.132  28.159  15.255  1.00 10.13           C  
+ATOM    206  C   ASN A  27      -5.317  26.889  15.464  1.00  2.57           C  
+ATOM    207  O   ASN A  27      -4.057  26.899  15.477  1.00  7.08           O  
+ATOM    208  CB  ASN A  27      -6.688  28.636  16.631  1.00  9.13           C  
+ATOM    209  CG  ASN A  27      -7.131  30.092  16.624  1.00  4.84           C  
+ATOM    210  OD1 ASN A  27      -6.292  30.979  16.582  1.00  9.37           O  
+ATOM    211  ND2 ASN A  27      -8.466  30.324  16.587  1.00  8.00           N  
+ATOM    212  N   TRP A  28      -6.033  25.791  15.639  1.00  5.40           N  
+ATOM    213  CA  TRP A  28      -5.402  24.497  15.879  1.00  5.45           C  
+ATOM    214  C   TRP A  28      -4.584  24.047  14.657  1.00  6.38           C  
+ATOM    215  O   TRP A  28      -3.510  23.501  14.767  1.00  7.31           O  
+ATOM    216  CB  TRP A  28      -6.482  23.490  16.237  1.00  7.31           C  
+ATOM    217  CG  TRP A  28      -7.149  23.849  17.539  1.00  7.66           C  
+ATOM    218  CD1 TRP A  28      -8.351  24.415  17.748  1.00 11.80           C  
+ATOM    219  CD2 TRP A  28      -6.540  23.691  18.841  1.00  9.47           C  
+ATOM    220  NE1 TRP A  28      -8.575  24.567  19.117  1.00 11.48           N  
+ATOM    221  CE2 TRP A  28      -7.475  24.139  19.807  1.00  9.56           C  
+ATOM    222  CE3 TRP A  28      -5.321  23.121  19.249  1.00 10.24           C  
+ATOM    223  CZ2 TRP A  28      -7.187  24.066  21.210  1.00 11.03           C  
+ATOM    224  CZ3 TRP A  28      -5.059  23.060  20.609  1.00 20.66           C  
+ATOM    225  CH2 TRP A  28      -5.985  23.551  21.560  1.00  9.06           C  
+ATOM    226  N   VAL A  29      -5.166  24.262  13.469  1.00  3.89           N  
+ATOM    227  CA  VAL A  29      -4.458  23.870  12.217  1.00  5.65           C  
+ATOM    228  C   VAL A  29      -3.242  24.746  11.972  1.00  2.99           C  
+ATOM    229  O   VAL A  29      -2.170  24.273  11.571  1.00  7.90           O  
+ATOM    230  CB  VAL A  29      -5.456  23.881  11.020  1.00  7.66           C  
+ATOM    231  CG1 VAL A  29      -4.630  23.646   9.743  1.00 13.23           C  
+ATOM    232  CG2 VAL A  29      -6.516  22.751  11.149  1.00  6.73           C  
+ATOM    233  N   CYS A  30      -3.372  26.060  12.262  1.00  2.63           N  
+ATOM    234  CA  CYS A  30      -2.281  26.976  12.125  1.00  7.05           C  
+ATOM    235  C   CYS A  30      -1.151  26.582  13.072  1.00 10.47           C  
+ATOM    236  O   CYS A  30       0.054  26.552  12.766  1.00  4.93           O  
+ATOM    237  CB  CYS A  30      -2.756  28.428  12.303  1.00  2.61           C  
+ATOM    238  SG  CYS A  30      -1.467  29.667  12.134  1.00 10.20           S  
+ATOM    239  N   ALA A  31      -1.521  26.283  14.306  1.00  9.82           N  
+ATOM    240  CA  ALA A  31      -0.491  25.884  15.276  1.00 15.61           C  
+ATOM    241  C   ALA A  31       0.235  24.607  14.849  1.00  5.07           C  
+ATOM    242  O   ALA A  31       1.464  24.554  14.987  1.00  9.27           O  
+ATOM    243  CB  ALA A  31      -1.089  25.781  16.704  1.00  7.85           C  
+ATOM    244  N   ALA A  32      -0.483  23.609  14.315  1.00  7.79           N  
+ATOM    245  CA  ALA A  32       0.162  22.357  13.855  1.00  8.61           C  
+ATOM    246  C   ALA A  32       1.085  22.594  12.673  1.00  7.90           C  
+ATOM    247  O   ALA A  32       2.197  22.050  12.585  1.00  9.35           O  
+ATOM    248  CB  ALA A  32      -0.823  21.268  13.540  1.00 10.83           C  
+ATOM    249  N   LYS A  33       0.653  23.463  11.786  1.00  7.35           N  
+ATOM    250  CA  LYS A  33       1.542  23.795  10.635  1.00  6.50           C  
+ATOM    251  C   LYS A  33       2.867  24.333  11.097  1.00  6.89           C  
+ATOM    252  O   LYS A  33       3.936  23.889  10.727  1.00 10.45           O  
+ATOM    253  CB  LYS A  33       0.863  24.886   9.776  1.00 10.32           C  
+ATOM    254  CG  LYS A  33       1.793  25.437   8.676  1.00 13.52           C  
+ATOM    255  CD  LYS A  33       1.927  24.485   7.491  1.00 19.87           C  
+ATOM    256  CE  LYS A  33       3.138  24.764   6.621  1.00 27.04           C  
+ATOM    257  NZ  LYS A  33       3.217  23.793   5.511  1.00 45.44           N  
+ATOM    258  N   PHE A  34       2.807  25.345  11.961  1.00  9.24           N  
+ATOM    259  CA  PHE A  34       4.029  25.958  12.436  1.00  8.96           C  
+ATOM    260  C   PHE A  34       4.846  25.192  13.455  1.00 16.48           C  
+ATOM    261  O   PHE A  34       6.039  25.360  13.540  1.00 14.96           O  
+ATOM    262  CB  PHE A  34       3.856  27.469  12.721  1.00  9.21           C  
+ATOM    263  CG  PHE A  34       3.417  28.201  11.426  1.00 11.78           C  
+ATOM    264  CD1 PHE A  34       4.231  28.189  10.282  1.00 11.49           C  
+ATOM    265  CD2 PHE A  34       2.212  28.933  11.385  1.00 12.86           C  
+ATOM    266  CE1 PHE A  34       3.830  28.854   9.136  1.00 12.74           C  
+ATOM    267  CE2 PHE A  34       1.803  29.618  10.224  1.00 13.38           C  
+ATOM    268  CZ  PHE A  34       2.627  29.554   9.090  1.00 13.39           C  
+ATOM    269  N   GLU A  35       4.201  24.324  14.225  1.00  9.90           N  
+ATOM    270  CA  GLU A  35       4.889  23.543  15.263  1.00 11.92           C  
+ATOM    271  C   GLU A  35       5.641  22.352  14.706  1.00 13.79           C  
+ATOM    272  O   GLU A  35       6.781  22.129  15.054  1.00  8.23           O  
+ATOM    273  CB  GLU A  35       3.839  23.026  16.259  1.00  6.00           C  
+ATOM    274  CG  GLU A  35       3.409  24.107  17.322  1.00 11.89           C  
+ATOM    275  CD  GLU A  35       4.516  24.690  18.200  1.00 12.03           C  
+ATOM    276  OE1 GLU A  35       5.640  24.296  18.226  1.00 12.97           O  
+ATOM    277  OE2 GLU A  35       4.167  25.730  18.876  1.00 13.03           O  
+ATOM    278  N   SER A  36       4.983  21.591  13.819  1.00  8.49           N  
+ATOM    279  CA  SER A  36       5.541  20.369  13.283  1.00  8.82           C  
+ATOM    280  C   SER A  36       5.483  20.189  11.756  1.00 10.13           C  
+ATOM    281  O   SER A  36       5.800  19.070  11.251  1.00 14.88           O  
+ATOM    282  CB  SER A  36       4.684  19.256  13.831  1.00  7.77           C  
+ATOM    283  OG  SER A  36       3.330  19.336  13.297  1.00  8.30           O  
+ATOM    284  N   ASN A  37       4.975  21.223  11.050  1.00 11.55           N  
+ATOM    285  CA  ASN A  37       4.752  21.103   9.605  1.00  8.89           C  
+ATOM    286  C   ASN A  37       3.825  19.918   9.321  1.00 14.33           C  
+ATOM    287  O   ASN A  37       3.972  19.215   8.320  1.00 14.19           O  
+ATOM    288  CB  ASN A  37       6.061  21.002   8.788  1.00 20.93           C  
+ATOM    289  CG  ASN A  37       5.851  21.458   7.334  1.00 25.83           C  
+ATOM    290  OD1 ASN A  37       5.061  22.365   7.057  1.00 26.84           O  
+ATOM    291  ND2 ASN A  37       6.474  20.759   6.397  1.00 52.87           N  
+ATOM    292  N   PHE A  38       2.864  19.696  10.220  1.00  7.19           N  
+ATOM    293  CA  PHE A  38       1.862  18.625  10.075  1.00 11.76           C  
+ATOM    294  C   PHE A  38       2.411  17.214  10.168  1.00 10.63           C  
+ATOM    295  O   PHE A  38       1.747  16.276   9.742  1.00  9.49           O  
+ATOM    296  CB  PHE A  38       1.092  18.696   8.696  1.00  8.56           C  
+ATOM    297  CG  PHE A  38       0.280  19.956   8.505  1.00 13.59           C  
+ATOM    298  CD1 PHE A  38      -0.367  20.558   9.597  1.00  8.45           C  
+ATOM    299  CD2 PHE A  38       0.112  20.532   7.255  1.00 17.61           C  
+ATOM    300  CE1 PHE A  38      -1.146  21.685   9.432  1.00 11.53           C  
+ATOM    301  CE2 PHE A  38      -0.664  21.687   7.081  1.00 17.65           C  
+ATOM    302  CZ  PHE A  38      -1.316  22.268   8.162  1.00 13.17           C  
+ATOM    303  N   ASN A  39       3.667  17.073  10.600  1.00  8.40           N  
+ATOM    304  CA  ASN A  39       4.271  15.737  10.699  1.00  6.01           C  
+ATOM    305  C   ASN A  39       4.101  15.211  12.158  1.00  6.81           C  
+ATOM    306  O   ASN A  39       4.597  15.858  13.147  1.00 11.41           O  
+ATOM    307  CB  ASN A  39       5.776  15.925  10.373  1.00  6.39           C  
+ATOM    308  CG  ASN A  39       6.552  14.636  10.450  1.00  6.34           C  
+ATOM    309  OD1 ASN A  39       5.992  13.541  10.684  1.00 10.75           O  
+ATOM    310  ND2 ASN A  39       7.832  14.764  10.100  1.00 13.88           N  
+ATOM    311  N   THR A  40       3.430  14.054  12.314  1.00  8.05           N  
+ATOM    312  CA  THR A  40       3.222  13.509  13.676  1.00 10.13           C  
+ATOM    313  C   THR A  40       4.525  13.041  14.358  1.00  8.64           C  
+ATOM    314  O   THR A  40       4.546  12.831  15.542  1.00 12.11           O  
+ATOM    315  CB  THR A  40       2.279  12.302  13.663  1.00 12.49           C  
+ATOM    316  OG1 THR A  40       2.862  11.250  12.880  1.00 10.89           O  
+ATOM    317  CG2 THR A  40       0.843  12.666  13.219  1.00  9.90           C  
+ATOM    318  N   GLN A  41       5.594  12.819  13.559  1.00  6.61           N  
+ATOM    319  CA  GLN A  41       6.860  12.308  14.019  1.00  3.67           C  
+ATOM    320  C   GLN A  41       7.861  13.372  14.433  1.00  4.66           C  
+ATOM    321  O   GLN A  41       8.986  13.051  14.864  1.00  8.80           O  
+ATOM    322  CB  GLN A  41       7.463  11.344  12.979  1.00  9.30           C  
+ATOM    323  CG  GLN A  41       6.598  10.100  12.797  1.00 12.21           C  
+ATOM    324  CD  GLN A  41       7.402   8.999  12.104  1.00 22.47           C  
+ATOM    325  OE1 GLN A  41       8.254   8.393  12.763  1.00 16.54           O  
+ATOM    326  NE2 GLN A  41       7.257   8.847  10.744  1.00 13.11           N  
+ATOM    327  N   ALA A  42       7.460  14.657  14.305  1.00  6.51           N  
+ATOM    328  CA  ALA A  42       8.376  15.748  14.672  1.00  8.14           C  
+ATOM    329  C   ALA A  42       8.824  15.710  16.237  1.00 11.70           C  
+ATOM    330  O   ALA A  42       8.005  15.547  17.165  1.00  5.54           O  
+ATOM    331  CB  ALA A  42       7.744  17.108  14.349  1.00  8.97           C  
+ATOM    332  N   THR A  43      10.132  15.865  16.445  1.00  7.08           N  
+ATOM    333  CA  THR A  43      10.705  15.992  17.773  1.00 10.42           C  
+ATOM    334  C   THR A  43      11.694  17.112  17.692  1.00 11.09           C  
+ATOM    335  O   THR A  43      12.280  17.411  16.646  1.00 12.80           O  
+ATOM    336  CB  THR A  43      11.362  14.748  18.354  1.00 13.93           C  
+ATOM    337  OG1 THR A  43      12.360  14.429  17.435  1.00 11.09           O  
+ATOM    338  CG2 THR A  43      10.420  13.567  18.530  1.00  7.58           C  
+ATOM    339  N   ASN A  44      11.894  17.801  18.808  1.00 10.77           N  
+ATOM    340  CA  ASN A  44      12.828  18.909  18.863  1.00  6.02           C  
+ATOM    341  C   ASN A  44      13.258  19.036  20.281  1.00 16.51           C  
+ATOM    342  O   ASN A  44      12.426  19.127  21.185  1.00 11.61           O  
+ATOM    343  CB  ASN A  44      12.171  20.225  18.473  1.00 13.37           C  
+ATOM    344  CG  ASN A  44      11.932  20.272  16.966  1.00 55.95           C  
+ATOM    345  OD1 ASN A  44      12.883  20.299  16.146  1.00 30.16           O  
+ATOM    346  ND2 ASN A  44      10.659  20.233  16.594  1.00 20.67           N  
+ATOM    347  N   ARG A  45      14.545  19.035  20.479  1.00 13.41           N  
+ATOM    348  CA  ARG A  45      15.061  19.112  21.827  1.00 12.01           C  
+ATOM    349  C   ARG A  45      15.250  20.555  22.252  1.00 20.93           C  
+ATOM    350  O   ARG A  45      15.601  21.418  21.435  1.00 20.22           O  
+ATOM    351  CB  ARG A  45      16.408  18.438  21.953  1.00 19.70           C  
+ATOM    352  CG  ARG A  45      16.935  18.714  23.338  1.00 35.82           C  
+ATOM    353  CD  ARG A  45      16.730  17.468  24.141  1.00 27.63           C  
+ATOM    354  NE  ARG A  45      17.249  16.408  23.330  1.00 67.37           N  
+ATOM    355  CZ  ARG A  45      18.249  15.588  23.641  1.00 91.84           C  
+ATOM    356  NH1 ARG A  45      18.868  15.589  24.830  1.00 36.08           N  
+ATOM    357  NH2 ARG A  45      18.624  14.698  22.716  1.00 64.26           N  
+ATOM    358  N   ASN A  46      15.056  20.796  23.543  1.00 12.63           N  
+ATOM    359  CA  ASN A  46      15.247  22.135  24.062  1.00 12.92           C  
+ATOM    360  C   ASN A  46      16.508  22.245  24.900  1.00  8.11           C  
+ATOM    361  O   ASN A  46      17.149  21.253  25.274  1.00 15.77           O  
+ATOM    362  CB  ASN A  46      13.989  22.699  24.735  1.00 11.70           C  
+ATOM    363  CG  ASN A  46      12.659  22.418  24.007  1.00 21.14           C  
+ATOM    364  OD1 ASN A  46      11.762  21.669  24.459  1.00 23.29           O  
+ATOM    365  ND2 ASN A  46      12.508  23.062  22.886  1.00 24.99           N  
+ATOM    366  N   THR A  47      16.906  23.489  25.146  1.00 23.92           N  
+ATOM    367  CA  THR A  47      18.108  23.768  25.931  1.00 39.90           C  
+ATOM    368  C   THR A  47      17.996  23.269  27.358  1.00 25.44           C  
+ATOM    369  O   THR A  47      18.958  22.798  27.923  1.00 34.24           O  
+ATOM    370  CB  THR A  47      18.506  25.250  25.905  1.00 47.42           C  
+ATOM    371  OG1 THR A  47      17.376  26.053  26.142  1.00 38.53           O  
+ATOM    372  CG2 THR A  47      19.115  25.572  24.552  1.00 58.08           C  
+ATOM    373  N   ASP A  48      16.797  23.339  27.935  1.00 20.62           N  
+ATOM    374  CA  ASP A  48      16.626  22.832  29.261  1.00  9.90           C  
+ATOM    375  C   ASP A  48      16.700  21.306  29.306  1.00 19.23           C  
+ATOM    376  O   ASP A  48      16.586  20.723  30.361  1.00 22.36           O  
+ATOM    377  CB  ASP A  48      15.349  23.377  29.887  1.00 14.78           C  
+ATOM    378  CG  ASP A  48      14.119  22.821  29.267  1.00 19.04           C  
+ATOM    379  OD1 ASP A  48      14.160  21.981  28.422  1.00 28.31           O  
+ATOM    380  OD2 ASP A  48      13.002  23.315  29.717  1.00 28.61           O  
+ATOM    381  N   GLY A  49      16.883  20.637  28.166  1.00 17.28           N  
+ATOM    382  CA  GLY A  49      16.950  19.205  28.182  1.00 10.24           C  
+ATOM    383  C   GLY A  49      15.608  18.534  27.977  1.00 14.24           C  
+ATOM    384  O   GLY A  49      15.499  17.291  27.852  1.00 13.58           O  
+ATOM    385  N   SER A  50      14.564  19.331  27.973  1.00  9.07           N  
+ATOM    386  CA  SER A  50      13.311  18.716  27.712  1.00  7.32           C  
+ATOM    387  C   SER A  50      13.217  18.531  26.131  1.00 11.52           C  
+ATOM    388  O   SER A  50      14.085  19.016  25.374  1.00 13.96           O  
+ATOM    389  CB  SER A  50      12.113  19.490  28.182  1.00  4.67           C  
+ATOM    390  OG  SER A  50      12.074  20.716  27.461  1.00  9.76           O  
+ATOM    391  N   THR A  51      12.150  17.857  25.646  1.00 11.43           N  
+ATOM    392  CA  THR A  51      11.958  17.610  24.179  1.00  9.12           C  
+ATOM    393  C   THR A  51      10.485  17.806  23.917  1.00 16.87           C  
+ATOM    394  O   THR A  51       9.677  17.499  24.825  1.00  8.33           O  
+ATOM    395  CB  THR A  51      12.363  16.177  23.757  1.00  5.49           C  
+ATOM    396  OG1 THR A  51      13.711  15.986  24.120  1.00  6.88           O  
+ATOM    397  CG2 THR A  51      12.234  15.930  22.227  1.00  7.94           C  
+ATOM    398  N   ASP A  52      10.158  18.354  22.701  1.00  9.46           N  
+ATOM    399  CA  ASP A  52       8.767  18.608  22.181  1.00  5.88           C  
+ATOM    400  C   ASP A  52       8.451  17.463  21.198  1.00  5.87           C  
+ATOM    401  O   ASP A  52       9.311  17.033  20.476  1.00  5.53           O  
+ATOM    402  CB  ASP A  52       8.717  19.972  21.485  1.00  6.73           C  
+ATOM    403  CG  ASP A  52       9.014  21.046  22.449  1.00 17.46           C  
+ATOM    404  OD1 ASP A  52       8.778  20.978  23.593  1.00 16.69           O  
+ATOM    405  OD2 ASP A  52       9.531  22.065  21.923  1.00 28.92           O  
+ATOM    406  N   TYR A  53       7.279  16.908  21.280  1.00  7.33           N  
+ATOM    407  CA  TYR A  53       6.899  15.745  20.548  1.00  9.37           C  
+ATOM    408  C   TYR A  53       5.580  15.922  19.790  1.00 13.52           C  
+ATOM    409  O   TYR A  53       4.554  16.399  20.326  1.00  7.94           O  
+ATOM    410  CB  TYR A  53       6.630  14.562  21.517  1.00  7.91           C  
+ATOM    411  CG  TYR A  53       7.865  14.099  22.242  1.00  6.82           C  
+ATOM    412  CD1 TYR A  53       8.335  14.742  23.399  1.00  8.88           C  
+ATOM    413  CD2 TYR A  53       8.618  13.027  21.749  1.00  6.30           C  
+ATOM    414  CE1 TYR A  53       9.548  14.382  24.006  1.00  1.83           C  
+ATOM    415  CE2 TYR A  53       9.846  12.646  22.351  1.00 10.07           C  
+ATOM    416  CZ  TYR A  53      10.229  13.264  23.534  1.00  8.70           C  
+ATOM    417  OH  TYR A  53      11.374  12.889  24.151  1.00 12.40           O  
+ATOM    418  N   GLY A  54       5.598  15.446  18.516  1.00 11.04           N  
+ATOM    419  CA  GLY A  54       4.390  15.347  17.710  1.00  7.71           C  
+ATOM    420  C   GLY A  54       3.939  16.599  17.020  1.00  3.67           C  
+ATOM    421  O   GLY A  54       4.535  17.621  17.017  1.00  8.49           O  
+ATOM    422  N   ILE A  55       2.748  16.458  16.496  1.00 11.91           N  
+ATOM    423  CA  ILE A  55       2.096  17.435  15.686  1.00  7.88           C  
+ATOM    424  C   ILE A  55       1.893  18.749  16.386  1.00 10.21           C  
+ATOM    425  O   ILE A  55       1.904  19.805  15.761  1.00  9.17           O  
+ATOM    426  CB  ILE A  55       0.838  16.805  15.068  1.00 19.48           C  
+ATOM    427  CG1 ILE A  55       0.390  17.438  13.734  1.00 15.27           C  
+ATOM    428  CG2 ILE A  55      -0.262  16.528  16.106  1.00 16.63           C  
+ATOM    429  CD1 ILE A  55      -0.353  16.483  12.846  1.00 21.60           C  
+ATOM    430  N   LEU A  56       1.765  18.677  17.706  1.00  9.90           N  
+ATOM    431  CA  LEU A  56       1.584  19.877  18.488  1.00  7.23           C  
+ATOM    432  C   LEU A  56       2.735  20.173  19.390  1.00 18.66           C  
+ATOM    433  O   LEU A  56       2.660  21.074  20.200  1.00 10.73           O  
+ATOM    434  CB  LEU A  56       0.216  19.957  19.205  1.00 11.28           C  
+ATOM    435  CG  LEU A  56      -0.990  20.157  18.283  1.00 12.31           C  
+ATOM    436  CD1 LEU A  56      -2.255  19.795  19.036  1.00 11.09           C  
+ATOM    437  CD2 LEU A  56      -1.074  21.607  17.850  1.00 11.43           C  
+ATOM    438  N   GLN A  57       3.804  19.441  19.202  1.00  7.01           N  
+ATOM    439  CA  GLN A  57       5.029  19.733  19.898  1.00  9.13           C  
+ATOM    440  C   GLN A  57       4.883  19.918  21.451  1.00 11.13           C  
+ATOM    441  O   GLN A  57       5.272  20.968  22.020  1.00 12.02           O  
+ATOM    442  CB  GLN A  57       5.767  20.937  19.263  1.00 10.29           C  
+ATOM    443  CG  GLN A  57       6.362  20.658  17.863  1.00  6.27           C  
+ATOM    444  CD  GLN A  57       7.544  19.747  17.936  1.00  2.25           C  
+ATOM    445  OE1 GLN A  57       8.676  20.257  18.147  1.00  7.47           O  
+ATOM    446  NE2 GLN A  57       7.279  18.413  17.746  1.00  7.69           N  
+ATOM    447  N   ILE A  58       4.303  18.898  22.061  1.00  9.58           N  
+ATOM    448  CA  ILE A  58       4.031  18.814  23.487  1.00 12.88           C  
+ATOM    449  C   ILE A  58       5.301  18.482  24.282  1.00 14.09           C  
+ATOM    450  O   ILE A  58       6.055  17.583  23.982  1.00 10.65           O  
+ATOM    451  CB  ILE A  58       2.839  17.923  23.711  1.00 12.15           C  
+ATOM    452  CG1 ILE A  58       1.599  18.614  23.110  1.00 12.61           C  
+ATOM    453  CG2 ILE A  58       2.704  17.544  25.215  1.00 12.37           C  
+ATOM    454  CD1 ILE A  58       0.329  17.770  23.138  1.00 17.22           C  
+ATOM    455  N   ASN A  59       5.556  19.297  25.282  1.00 11.07           N  
+ATOM    456  CA  ASN A  59       6.797  19.305  26.034  1.00  6.68           C  
+ATOM    457  C   ASN A  59       6.893  18.239  27.099  1.00  8.46           C  
+ATOM    458  O   ASN A  59       5.904  18.002  27.761  1.00 12.15           O  
+ATOM    459  CB  ASN A  59       7.045  20.721  26.565  1.00  7.94           C  
+ATOM    460  CG  ASN A  59       8.434  20.839  27.178  1.00 12.92           C  
+ATOM    461  OD1 ASN A  59       8.578  20.809  28.411  1.00 30.15           O  
+ATOM    462  ND2 ASN A  59       9.469  20.939  26.342  1.00 15.71           N  
+ATOM    463  N   SER A  60       8.096  17.590  27.218  1.00  8.63           N  
+ATOM    464  CA  SER A  60       8.333  16.496  28.162  1.00 11.30           C  
+ATOM    465  C   SER A  60       8.586  17.015  29.647  1.00  7.42           C  
+ATOM    466  O   SER A  60       8.559  16.218  30.620  1.00 18.39           O  
+ATOM    467  CB  SER A  60       9.448  15.619  27.698  1.00  9.31           C  
+ATOM    468  OG  SER A  60      10.642  16.390  27.790  1.00  9.01           O  
+ATOM    469  N   ARG A  61       8.806  18.347  29.787  1.00 11.96           N  
+ATOM    470  CA  ARG A  61       8.981  18.933  31.125  1.00 18.58           C  
+ATOM    471  C   ARG A  61       7.701  18.806  31.935  1.00 21.66           C  
+ATOM    472  O   ARG A  61       7.730  18.363  33.063  1.00 24.43           O  
+ATOM    473  CB  ARG A  61       9.507  20.347  31.068  1.00 19.81           C  
+ATOM    474  CG  ARG A  61       9.259  21.125  32.338  1.00 40.52           C  
+ATOM    475  CD  ARG A  61      10.511  21.648  33.063  1.00 30.90           C  
+ATOM    476  NE  ARG A  61      11.777  21.523  32.353  1.00 58.97           N  
+ATOM    477  CZ  ARG A  61      12.722  20.587  32.539  1.00 70.61           C  
+ATOM    478  NH1 ARG A  61      12.610  19.570  33.413  1.00 68.85           N  
+ATOM    479  NH2 ARG A  61      13.829  20.673  31.795  1.00 56.33           N  
+ATOM    480  N   TRP A  62       6.542  19.071  31.329  1.00 12.69           N  
+ATOM    481  CA  TRP A  62       5.279  18.955  32.026  1.00 10.92           C  
+ATOM    482  C   TRP A  62       4.281  17.916  31.682  1.00 19.26           C  
+ATOM    483  O   TRP A  62       3.526  17.478  32.563  1.00 19.01           O  
+ATOM    484  CB  TRP A  62       4.455  20.234  31.875  1.00 14.48           C  
+ATOM    485  CG  TRP A  62       5.346  21.376  31.920  1.00 34.77           C  
+ATOM    486  CD1 TRP A  62       5.937  21.965  30.857  1.00 48.56           C  
+ATOM    487  CD2 TRP A  62       5.859  21.980  33.091  1.00 34.03           C  
+ATOM    488  NE1 TRP A  62       6.753  22.970  31.303  1.00 60.61           N  
+ATOM    489  CE2 TRP A  62       6.730  22.995  32.671  1.00 37.59           C  
+ATOM    490  CE3 TRP A  62       5.619  21.790  34.443  1.00 44.85           C  
+ATOM    491  CZ2 TRP A  62       7.373  23.823  33.582  1.00 74.91           C  
+ATOM    492  CZ3 TRP A  62       6.254  22.606  35.347  1.00 49.52           C  
+ATOM    493  CH2 TRP A  62       7.122  23.609  34.923  1.00 52.73           C  
+ATOM    494  N   TRP A  63       4.152  17.600  30.385  1.00 11.21           N  
+ATOM    495  CA  TRP A  63       3.036  16.858  29.848  1.00  9.63           C  
+ATOM    496  C   TRP A  63       3.155  15.396  29.592  1.00  4.89           C  
+ATOM    497  O   TRP A  63       2.183  14.725  29.581  1.00 11.10           O  
+ATOM    498  CB  TRP A  63       2.652  17.635  28.566  1.00  6.50           C  
+ATOM    499  CG  TRP A  63       2.429  19.101  28.874  1.00  5.59           C  
+ATOM    500  CD1 TRP A  63       3.223  20.140  28.615  1.00 15.86           C  
+ATOM    501  CD2 TRP A  63       1.364  19.632  29.695  1.00 11.68           C  
+ATOM    502  NE1 TRP A  63       2.675  21.309  29.075  1.00 15.89           N  
+ATOM    503  CE2 TRP A  63       1.567  21.028  29.780  1.00 12.27           C  
+ATOM    504  CE3 TRP A  63       0.230  19.055  30.324  1.00 14.52           C  
+ATOM    505  CZ2 TRP A  63       0.682  21.862  30.488  1.00 10.75           C  
+ATOM    506  CZ3 TRP A  63      -0.678  19.891  30.985  1.00 10.21           C  
+ATOM    507  CH2 TRP A  63      -0.421  21.271  31.057  1.00 13.33           C  
+ATOM    508  N   CYS A  64       4.324  14.905  29.353  1.00  8.53           N  
+ATOM    509  CA  CYS A  64       4.448  13.469  29.032  1.00 14.18           C  
+ATOM    510  C   CYS A  64       5.785  12.968  29.569  1.00  8.75           C  
+ATOM    511  O   CYS A  64       6.694  13.742  29.793  1.00 11.88           O  
+ATOM    512  CB  CYS A  64       4.366  13.241  27.432  1.00 12.87           C  
+ATOM    513  SG  CYS A  64       5.695  14.086  26.427  1.00  9.81           S  
+ATOM    514  N   ASN A  65       5.913  11.651  29.720  1.00  9.55           N  
+ATOM    515  CA  ASN A  65       7.127  11.114  30.200  1.00 16.84           C  
+ATOM    516  C   ASN A  65       7.999  10.547  29.073  1.00  4.97           C  
+ATOM    517  O   ASN A  65       7.529   9.623  28.435  1.00 10.83           O  
+ATOM    518  CB  ASN A  65       6.809   9.953  31.188  1.00  9.17           C  
+ATOM    519  CG  ASN A  65       8.120   9.322  31.715  1.00 22.59           C  
+ATOM    520  OD1 ASN A  65       9.033  10.017  32.182  1.00 21.36           O  
+ATOM    521  ND2 ASN A  65       8.276   8.015  31.524  1.00 36.98           N  
+ATOM    522  N   ASP A  66       9.254  10.993  28.982  1.00  7.66           N  
+ATOM    523  CA  ASP A  66      10.153  10.434  27.995  1.00 14.97           C  
+ATOM    524  C   ASP A  66      11.354   9.742  28.601  1.00 23.09           C  
+ATOM    525  O   ASP A  66      12.237   9.341  27.867  1.00  9.43           O  
+ATOM    526  CB  ASP A  66      10.641  11.448  26.948  1.00 13.58           C  
+ATOM    527  CG  ASP A  66      11.480  12.554  27.535  1.00 11.41           C  
+ATOM    528  OD1 ASP A  66      11.787  12.613  28.717  1.00 18.43           O  
+ATOM    529  OD2 ASP A  66      11.850  13.432  26.659  1.00 10.72           O  
+ATOM    530  N   GLY A  67      11.395   9.644  29.920  1.00 14.60           N  
+ATOM    531  CA  GLY A  67      12.449   8.941  30.665  1.00  9.04           C  
+ATOM    532  C   GLY A  67      13.738   9.677  30.697  1.00 13.04           C  
+ATOM    533  O   GLY A  67      14.726   9.165  31.164  1.00 23.22           O  
+ATOM    534  N   ARG A  68      13.787  10.891  30.194  1.00  8.50           N  
+ATOM    535  CA  ARG A  68      15.089  11.512  30.237  1.00 11.50           C  
+ATOM    536  C   ARG A  68      15.046  12.949  30.560  1.00 11.49           C  
+ATOM    537  O   ARG A  68      15.995  13.645  30.281  1.00 17.90           O  
+ATOM    538  CB  ARG A  68      15.872  11.277  28.959  1.00 18.67           C  
+ATOM    539  CG  ARG A  68      15.218  11.867  27.707  1.00 21.19           C  
+ATOM    540  CD  ARG A  68      16.251  12.103  26.592  1.00 19.51           C  
+ATOM    541  NE  ARG A  68      15.790  12.984  25.527  1.00 20.38           N  
+ATOM    542  CZ  ARG A  68      16.264  12.978  24.248  1.00 29.94           C  
+ATOM    543  NH1 ARG A  68      17.253  12.102  23.926  1.00 13.00           N  
+ATOM    544  NH2 ARG A  68      15.787  13.865  23.293  1.00 13.47           N  
+ATOM    545  N   THR A  69      13.937  13.376  31.145  1.00 12.12           N  
+ATOM    546  CA  THR A  69      13.674  14.782  31.586  1.00 17.22           C  
+ATOM    547  C   THR A  69      13.372  14.770  33.144  1.00 15.41           C  
+ATOM    548  O   THR A  69      12.260  14.526  33.618  1.00 19.26           O  
+ATOM    549  CB  THR A  69      12.464  15.410  30.798  1.00 12.81           C  
+ATOM    550  OG1 THR A  69      12.589  15.107  29.412  1.00 17.25           O  
+ATOM    551  CG2 THR A  69      12.392  16.932  30.990  1.00  8.98           C  
+ATOM    552  N   PRO A  70      14.431  14.960  33.874  1.00 30.00           N  
+ATOM    553  CA  PRO A  70      14.563  14.964  35.315  1.00 31.13           C  
+ATOM    554  C   PRO A  70      13.654  16.003  35.904  1.00 43.01           C  
+ATOM    555  O   PRO A  70      13.699  17.188  35.594  1.00 37.19           O  
+ATOM    556  CB  PRO A  70      16.056  15.221  35.541  1.00 43.11           C  
+ATOM    557  CG  PRO A  70      16.728  15.203  34.148  1.00 49.23           C  
+ATOM    558  CD  PRO A  70      15.635  15.319  33.119  1.00 44.60           C  
+ATOM    559  N   GLY A  71      12.698  15.573  36.672  1.00 29.79           N  
+ATOM    560  CA  GLY A  71      11.785  16.609  37.130  1.00 38.84           C  
+ATOM    561  C   GLY A  71      10.547  16.728  36.220  1.00 34.52           C  
+ATOM    562  O   GLY A  71       9.750  17.644  36.328  1.00 53.49           O  
+ATOM    563  N   SER A  72      10.339  15.797  35.324  1.00 30.26           N  
+ATOM    564  CA  SER A  72       9.157  15.860  34.502  1.00 32.28           C  
+ATOM    565  C   SER A  72       7.906  15.615  35.374  1.00 22.29           C  
+ATOM    566  O   SER A  72       7.914  14.715  36.197  1.00 26.48           O  
+ATOM    567  CB  SER A  72       9.249  14.700  33.473  1.00 31.83           C  
+ATOM    568  OG  SER A  72       8.038  14.552  32.612  1.00 33.11           O  
+ATOM    569  N   ARG A  73       6.801  16.311  35.113  1.00 20.31           N  
+ATOM    570  CA  ARG A  73       5.550  16.055  35.819  1.00 12.77           C  
+ATOM    571  C   ARG A  73       4.564  15.081  35.174  1.00 35.87           C  
+ATOM    572  O   ARG A  73       3.662  14.597  35.845  1.00 50.20           O  
+ATOM    573  CB  ARG A  73       4.830  17.322  36.128  1.00 19.66           C  
+ATOM    574  CG  ARG A  73       5.605  18.165  37.124  1.00 35.18           C  
+ATOM    575  CD  ARG A  73       4.864  19.471  37.396  1.00 86.10           C  
+ATOM    576  NE  ARG A  73       4.736  19.744  38.823  1.00 80.19           N  
+ATOM    577  CZ  ARG A  73       4.227  20.854  39.398  1.00 81.09           C  
+ATOM    578  NH1 ARG A  73       3.742  21.891  38.705  1.00 81.15           N  
+ATOM    579  NH2 ARG A  73       4.215  20.930  40.739  1.00 71.03           N  
+ATOM    580  N   ASN A  74       4.668  14.781  33.896  1.00 18.76           N  
+ATOM    581  CA  ASN A  74       3.715  13.833  33.313  1.00 10.40           C  
+ATOM    582  C   ASN A  74       2.194  14.147  33.501  1.00  8.97           C  
+ATOM    583  O   ASN A  74       1.355  13.278  33.697  1.00 15.29           O  
+ATOM    584  CB  ASN A  74       4.053  12.334  33.426  1.00 16.10           C  
+ATOM    585  CG  ASN A  74       3.479  11.413  32.309  1.00 15.75           C  
+ATOM    586  OD1 ASN A  74       2.928  11.864  31.297  1.00 22.77           O  
+ATOM    587  ND2 ASN A  74       3.593  10.101  32.490  1.00 17.62           N  
+ATOM    588  N   LEU A  75       1.851  15.405  33.334  1.00 13.92           N  
+ATOM    589  CA  LEU A  75       0.471  15.774  33.458  1.00 16.58           C  
+ATOM    590  C   LEU A  75      -0.505  15.089  32.565  1.00 21.84           C  
+ATOM    591  O   LEU A  75      -1.654  14.976  32.957  1.00 22.99           O  
+ATOM    592  CB  LEU A  75       0.245  17.277  33.466  1.00 17.10           C  
+ATOM    593  CG  LEU A  75       0.919  17.845  34.715  1.00 30.53           C  
+ATOM    594  CD1 LEU A  75       0.889  19.358  34.725  1.00 35.25           C  
+ATOM    595  CD2 LEU A  75       0.238  17.306  35.969  1.00 21.06           C  
+ATOM    596  N   CYS A  76      -0.146  14.663  31.359  1.00 18.42           N  
+ATOM    597  CA  CYS A  76      -1.153  13.970  30.513  1.00 10.67           C  
+ATOM    598  C   CYS A  76      -1.137  12.463  30.738  1.00 12.68           C  
+ATOM    599  O   CYS A  76      -1.935  11.725  30.131  1.00 17.21           O  
+ATOM    600  CB  CYS A  76      -1.094  14.295  28.984  1.00  9.97           C  
+ATOM    601  SG  CYS A  76      -1.329  16.050  28.713  1.00 13.70           S  
+ATOM    602  N   ASN A  77      -0.194  12.038  31.586  1.00 14.93           N  
+ATOM    603  CA  ASN A  77      -0.117  10.607  31.926  1.00 19.18           C  
+ATOM    604  C   ASN A  77       0.099   9.697  30.747  1.00 21.40           C  
+ATOM    605  O   ASN A  77      -0.626   8.715  30.538  1.00 17.53           O  
+ATOM    606  CB  ASN A  77      -1.421  10.174  32.620  1.00 36.06           C  
+ATOM    607  CG  ASN A  77      -1.361   8.783  33.215  1.00 80.95           C  
+ATOM    608  OD1 ASN A  77      -2.358   8.042  33.188  1.00 78.33           O  
+ATOM    609  ND2 ASN A  77      -0.186   8.412  33.715  1.00 38.97           N  
+ATOM    610  N   ILE A  78       1.114  10.006  29.979  1.00 14.33           N  
+ATOM    611  CA  ILE A  78       1.373   9.191  28.838  1.00 11.33           C  
+ATOM    612  C   ILE A  78       2.873   9.258  28.499  1.00 13.41           C  
+ATOM    613  O   ILE A  78       3.568  10.265  28.718  1.00 12.78           O  
+ATOM    614  CB  ILE A  78       0.764   9.855  27.598  1.00 15.98           C  
+ATOM    615  CG1 ILE A  78       0.764  11.376  27.743  1.00 20.19           C  
+ATOM    616  CG2 ILE A  78      -0.461   9.195  26.985  1.00 25.51           C  
+ATOM    617  CD1 ILE A  78       0.735  12.094  26.406  1.00 31.88           C  
+ATOM    618  N   PRO A  79       3.343   8.210  27.843  1.00 14.97           N  
+ATOM    619  CA  PRO A  79       4.715   8.229  27.362  1.00 12.65           C  
+ATOM    620  C   PRO A  79       4.738   9.234  26.187  1.00 10.18           C  
+ATOM    621  O   PRO A  79       3.762   9.304  25.359  1.00 11.71           O  
+ATOM    622  CB  PRO A  79       4.962   6.830  26.843  1.00 11.25           C  
+ATOM    623  CG  PRO A  79       3.631   6.096  26.844  1.00 17.21           C  
+ATOM    624  CD  PRO A  79       2.621   6.951  27.581  1.00  9.85           C  
+ATOM    625  N   CYS A  80       5.798  10.020  26.078  1.00 11.09           N  
+ATOM    626  CA  CYS A  80       5.870  11.003  24.969  1.00  5.24           C  
+ATOM    627  C   CYS A  80       5.782  10.359  23.546  1.00  8.89           C  
+ATOM    628  O   CYS A  80       5.284  10.950  22.568  1.00 11.52           O  
+ATOM    629  CB  CYS A  80       7.126  11.894  25.061  1.00  7.40           C  
+ATOM    630  SG  CYS A  80       7.251  12.847  26.592  1.00  9.47           S  
+ATOM    631  N   SER A  81       6.259   9.115  23.442  1.00  9.85           N  
+ATOM    632  CA  SER A  81       6.242   8.432  22.154  1.00  7.67           C  
+ATOM    633  C   SER A  81       4.815   8.223  21.687  1.00 15.55           C  
+ATOM    634  O   SER A  81       4.554   8.156  20.510  1.00 15.82           O  
+ATOM    635  CB  SER A  81       6.995   7.111  22.234  1.00 15.31           C  
+ATOM    636  OG  SER A  81       6.295   6.245  23.119  1.00 17.97           O  
+ATOM    637  N   ALA A  82       3.857   8.169  22.598  1.00 11.39           N  
+ATOM    638  CA  ALA A  82       2.452   8.033  22.185  1.00 14.65           C  
+ATOM    639  C   ALA A  82       2.000   9.216  21.325  1.00 20.26           C  
+ATOM    640  O   ALA A  82       1.033   9.113  20.571  1.00 22.13           O  
+ATOM    641  CB  ALA A  82       1.481   8.009  23.384  1.00 17.51           C  
+ATOM    642  N   LEU A  83       2.659  10.349  21.528  1.00  9.56           N  
+ATOM    643  CA  LEU A  83       2.329  11.589  20.867  1.00 12.01           C  
+ATOM    644  C   LEU A  83       2.834  11.627  19.385  1.00 18.14           C  
+ATOM    645  O   LEU A  83       2.626  12.620  18.685  1.00 12.31           O  
+ATOM    646  CB  LEU A  83       2.986  12.761  21.651  1.00 15.90           C  
+ATOM    647  CG  LEU A  83       2.370  12.966  23.055  1.00  9.43           C  
+ATOM    648  CD1 LEU A  83       3.076  14.069  23.849  1.00 12.61           C  
+ATOM    649  CD2 LEU A  83       0.843  13.174  22.965  1.00 15.37           C  
+ATOM    650  N   LEU A  84       3.542  10.556  18.940  1.00 13.34           N  
+ATOM    651  CA  LEU A  84       4.131  10.512  17.618  1.00 11.55           C  
+ATOM    652  C   LEU A  84       3.361   9.657  16.630  1.00 16.60           C  
+ATOM    653  O   LEU A  84       3.704   9.570  15.475  1.00 22.63           O  
+ATOM    654  CB  LEU A  84       5.630  10.044  17.645  1.00  7.92           C  
+ATOM    655  CG  LEU A  84       6.546  10.859  18.552  1.00 18.00           C  
+ATOM    656  CD1 LEU A  84       7.978  10.414  18.359  1.00 17.76           C  
+ATOM    657  CD2 LEU A  84       6.513  12.306  18.116  1.00  8.41           C  
+ATOM    658  N   SER A  85       2.332   9.023  17.096  1.00 15.68           N  
+ATOM    659  CA  SER A  85       1.485   8.148  16.333  1.00 22.63           C  
+ATOM    660  C   SER A  85       0.792   8.827  15.194  1.00 14.76           C  
+ATOM    661  O   SER A  85       0.519  10.007  15.280  1.00 16.99           O  
+ATOM    662  CB  SER A  85       0.376   7.776  17.295  1.00 16.59           C  
+ATOM    663  OG  SER A  85      -0.373   6.761  16.741  1.00 23.89           O  
+ATOM    664  N   SER A  86       0.371   8.039  14.186  1.00 19.04           N  
+ATOM    665  CA  SER A  86      -0.430   8.505  13.025  1.00 17.09           C  
+ATOM    666  C   SER A  86      -1.827   8.884  13.487  1.00 21.77           C  
+ATOM    667  O   SER A  86      -2.481   9.696  12.857  1.00 24.42           O  
+ATOM    668  CB  SER A  86      -0.584   7.358  12.026  1.00 21.75           C  
+ATOM    669  OG  SER A  86       0.687   7.146  11.467  1.00 50.53           O  
+ATOM    670  N   ASP A  87      -2.288   8.227  14.575  1.00 13.55           N  
+ATOM    671  CA  ASP A  87      -3.611   8.483  15.195  1.00 14.83           C  
+ATOM    672  C   ASP A  87      -3.426   9.673  16.162  1.00 16.43           C  
+ATOM    673  O   ASP A  87      -2.640   9.585  17.147  1.00 17.32           O  
+ATOM    674  CB  ASP A  87      -4.025   7.244  15.987  1.00 17.38           C  
+ATOM    675  CG  ASP A  87      -5.365   7.435  16.676  1.00 36.42           C  
+ATOM    676  OD1 ASP A  87      -5.875   8.512  16.868  1.00 21.05           O  
+ATOM    677  OD2 ASP A  87      -5.952   6.315  17.005  1.00 56.25           O  
+ATOM    678  N   ILE A  88      -4.037  10.803  15.879  1.00 12.05           N  
+ATOM    679  CA  ILE A  88      -3.749  11.974  16.722  1.00 17.85           C  
+ATOM    680  C   ILE A  88      -4.490  12.067  18.055  1.00 12.40           C  
+ATOM    681  O   ILE A  88      -4.393  13.081  18.780  1.00 11.64           O  
+ATOM    682  CB  ILE A  88      -4.014  13.293  15.954  1.00 16.92           C  
+ATOM    683  CG1 ILE A  88      -5.565  13.392  15.634  1.00 15.36           C  
+ATOM    684  CG2 ILE A  88      -3.104  13.384  14.694  1.00 18.11           C  
+ATOM    685  CD1 ILE A  88      -6.065  14.738  15.196  1.00 20.80           C  
+ATOM    686  N   THR A  89      -5.257  11.069  18.381  1.00 13.72           N  
+ATOM    687  CA  THR A  89      -6.058  11.103  19.584  1.00 12.45           C  
+ATOM    688  C   THR A  89      -5.326  11.520  20.907  1.00  8.02           C  
+ATOM    689  O   THR A  89      -5.777  12.403  21.614  1.00 14.43           O  
+ATOM    690  CB  THR A  89      -6.717   9.735  19.716  1.00 18.11           C  
+ATOM    691  OG1 THR A  89      -7.492   9.539  18.564  1.00 18.36           O  
+ATOM    692  CG2 THR A  89      -7.642   9.724  20.953  1.00 16.37           C  
+ATOM    693  N   ALA A  90      -4.186  10.900  21.216  1.00 10.40           N  
+ATOM    694  CA  ALA A  90      -3.483  11.250  22.444  1.00 14.23           C  
+ATOM    695  C   ALA A  90      -2.971  12.685  22.412  1.00 17.47           C  
+ATOM    696  O   ALA A  90      -2.981  13.344  23.413  1.00 10.92           O  
+ATOM    697  CB  ALA A  90      -2.331  10.290  22.751  1.00 15.55           C  
+ATOM    698  N   SER A  91      -2.504  13.185  21.257  1.00  8.67           N  
+ATOM    699  CA  SER A  91      -2.032  14.567  21.163  1.00  7.03           C  
+ATOM    700  C   SER A  91      -3.155  15.522  21.418  1.00  6.83           C  
+ATOM    701  O   SER A  91      -3.033  16.547  22.059  1.00 13.20           O  
+ATOM    702  CB  SER A  91      -1.445  14.870  19.783  1.00  7.71           C  
+ATOM    703  OG  SER A  91      -0.111  14.402  19.670  1.00 11.50           O  
+ATOM    704  N   VAL A  92      -4.289  15.234  20.839  1.00  9.57           N  
+ATOM    705  CA  VAL A  92      -5.449  16.101  21.004  1.00  7.79           C  
+ATOM    706  C   VAL A  92      -5.938  16.148  22.488  1.00 10.65           C  
+ATOM    707  O   VAL A  92      -6.254  17.195  23.018  1.00 12.26           O  
+ATOM    708  CB  VAL A  92      -6.523  15.597  19.994  1.00 23.58           C  
+ATOM    709  CG1 VAL A  92      -7.936  16.117  20.303  1.00 19.93           C  
+ATOM    710  CG2 VAL A  92      -6.110  15.987  18.555  1.00 17.17           C  
+ATOM    711  N   ASN A  93      -6.047  14.973  23.140  1.00 10.03           N  
+ATOM    712  CA  ASN A  93      -6.511  14.862  24.536  1.00 24.44           C  
+ATOM    713  C   ASN A  93      -5.602  15.647  25.472  1.00 10.79           C  
+ATOM    714  O   ASN A  93      -6.049  16.390  26.310  1.00 15.54           O  
+ATOM    715  CB  ASN A  93      -6.580  13.395  24.989  1.00 13.16           C  
+ATOM    716  CG  ASN A  93      -7.781  12.668  24.406  1.00 15.37           C  
+ATOM    717  OD1 ASN A  93      -7.842  11.422  24.426  1.00 35.75           O  
+ATOM    718  ND2 ASN A  93      -8.682  13.436  23.835  1.00 16.65           N  
+ATOM    719  N   CYS A  94      -4.284  15.477  25.249  1.00 10.49           N  
+ATOM    720  CA  CYS A  94      -3.267  16.178  25.984  1.00  7.62           C  
+ATOM    721  C   CYS A  94      -3.353  17.649  25.690  1.00 17.58           C  
+ATOM    722  O   CYS A  94      -3.298  18.462  26.598  1.00  9.76           O  
+ATOM    723  CB  CYS A  94      -1.875  15.620  25.709  1.00  5.33           C  
+ATOM    724  SG  CYS A  94      -0.613  16.312  26.762  1.00 13.87           S  
+ATOM    725  N   ALA A  95      -3.546  18.041  24.407  1.00  7.01           N  
+ATOM    726  CA  ALA A  95      -3.656  19.481  24.142  1.00  8.80           C  
+ATOM    727  C   ALA A  95      -4.864  20.156  24.849  1.00  8.68           C  
+ATOM    728  O   ALA A  95      -4.867  21.353  25.215  1.00 11.44           O  
+ATOM    729  CB  ALA A  95      -3.774  19.698  22.627  1.00  6.34           C  
+ATOM    730  N   LYS A  96      -5.932  19.405  24.966  1.00  9.62           N  
+ATOM    731  CA  LYS A  96      -7.108  19.927  25.596  1.00  9.41           C  
+ATOM    732  C   LYS A  96      -6.804  20.229  27.091  1.00 11.43           C  
+ATOM    733  O   LYS A  96      -7.271  21.199  27.627  1.00 15.34           O  
+ATOM    734  CB  LYS A  96      -8.195  18.868  25.472  1.00 12.74           C  
+ATOM    735  CG  LYS A  96      -8.927  18.820  24.137  1.00  9.62           C  
+ATOM    736  CD  LYS A  96      -9.976  17.699  24.147  1.00 14.08           C  
+ATOM    737  CE  LYS A  96     -10.973  17.784  22.960  1.00 16.34           C  
+ATOM    738  NZ  LYS A  96     -11.641  16.485  22.720  1.00 20.55           N  
+ATOM    739  N   LYS A  97      -5.944  19.447  27.750  1.00 13.54           N  
+ATOM    740  CA  LYS A  97      -5.538  19.706  29.158  1.00 14.41           C  
+ATOM    741  C   LYS A  97      -4.672  20.981  29.209  1.00 13.37           C  
+ATOM    742  O   LYS A  97      -4.809  21.878  30.014  1.00 13.38           O  
+ATOM    743  CB  LYS A  97      -4.710  18.544  29.689  1.00 10.77           C  
+ATOM    744  CG  LYS A  97      -5.493  17.342  30.140  1.00 32.04           C  
+ATOM    745  CD  LYS A  97      -6.434  17.637  31.297  1.00 45.76           C  
+ATOM    746  CE  LYS A  97      -7.073  16.369  31.886  1.00 70.47           C  
+ATOM    747  NZ  LYS A  97      -8.523  16.232  31.620  1.00 59.21           N  
+ATOM    748  N   ILE A  98      -3.760  21.072  28.264  1.00 12.65           N  
+ATOM    749  CA  ILE A  98      -2.856  22.204  28.161  1.00 10.78           C  
+ATOM    750  C   ILE A  98      -3.607  23.536  27.991  1.00  8.94           C  
+ATOM    751  O   ILE A  98      -3.322  24.532  28.701  1.00 12.98           O  
+ATOM    752  CB  ILE A  98      -1.778  22.026  27.022  1.00 17.91           C  
+ATOM    753  CG1 ILE A  98      -0.899  20.798  27.234  1.00 15.21           C  
+ATOM    754  CG2 ILE A  98      -0.932  23.292  26.811  1.00 10.73           C  
+ATOM    755  CD1 ILE A  98      -0.035  20.440  26.059  1.00  5.59           C  
+ATOM    756  N   VAL A  99      -4.497  23.570  26.973  1.00 12.61           N  
+ATOM    757  CA  VAL A  99      -5.194  24.822  26.643  1.00 14.92           C  
+ATOM    758  C   VAL A  99      -6.158  25.244  27.757  1.00 17.60           C  
+ATOM    759  O   VAL A  99      -6.529  26.431  27.844  1.00 21.46           O  
+ATOM    760  CB  VAL A  99      -5.863  24.788  25.223  1.00  7.93           C  
+ATOM    761  CG1 VAL A  99      -7.102  23.930  25.230  1.00 13.13           C  
+ATOM    762  CG2 VAL A  99      -6.203  26.159  24.648  1.00 14.05           C  
+ATOM    763  N   SER A 100      -6.529  24.274  28.623  1.00 14.94           N  
+ATOM    764  CA  SER A 100      -7.469  24.559  29.728  1.00 23.99           C  
+ATOM    765  C   SER A 100      -6.810  25.233  30.952  1.00 23.57           C  
+ATOM    766  O   SER A 100      -7.460  25.872  31.759  1.00 30.51           O  
+ATOM    767  CB  SER A 100      -8.109  23.250  30.148  1.00 15.96           C  
+ATOM    768  OG  SER A 100      -9.019  22.837  29.120  1.00 33.46           O  
+ATOM    769  N   ASP A 101      -5.495  25.061  30.981  1.00 27.50           N  
+ATOM    770  CA  ASP A 101      -4.485  25.414  31.955  1.00 38.61           C  
+ATOM    771  C   ASP A 101      -4.239  26.879  32.265  1.00 31.46           C  
+ATOM    772  O   ASP A 101      -3.422  27.194  33.137  1.00 49.53           O  
+ATOM    773  CB  ASP A 101      -3.173  24.648  31.624  1.00 32.62           C  
+ATOM    774  CG  ASP A 101      -2.133  24.566  32.715  1.00 66.21           C  
+ATOM    775  OD1 ASP A 101      -2.482  23.821  33.747  1.00 53.53           O  
+ATOM    776  OD2 ASP A 101      -1.045  25.095  32.609  1.00 62.33           O  
+ATOM    777  N   GLY A 102      -4.876  27.820  31.617  1.00 31.57           N  
+ATOM    778  CA  GLY A 102      -4.525  29.170  32.093  1.00 42.83           C  
+ATOM    779  C   GLY A 102      -4.082  30.192  31.049  1.00 56.99           C  
+ATOM    780  O   GLY A 102      -4.713  31.264  30.990  1.00 31.68           O  
+ATOM    781  N   ASN A 103      -2.979  29.915  30.284  1.00 23.55           N  
+ATOM    782  CA  ASN A 103      -2.573  30.864  29.246  1.00 11.97           C  
+ATOM    783  C   ASN A 103      -3.176  30.497  27.876  1.00  9.86           C  
+ATOM    784  O   ASN A 103      -2.905  31.106  26.860  1.00 13.84           O  
+ATOM    785  CB  ASN A 103      -1.070  31.114  29.177  1.00 17.92           C  
+ATOM    786  CG  ASN A 103      -0.638  31.476  30.587  1.00 65.73           C  
+ATOM    787  OD1 ASN A 103       0.384  30.993  31.105  1.00 74.71           O  
+ATOM    788  ND2 ASN A 103      -1.509  32.224  31.271  1.00 54.30           N  
+ATOM    789  N   GLY A 104      -4.070  29.522  27.865  1.00 10.94           N  
+ATOM    790  CA  GLY A 104      -4.733  29.138  26.601  1.00 18.78           C  
+ATOM    791  C   GLY A 104      -3.725  28.668  25.570  1.00  8.28           C  
+ATOM    792  O   GLY A 104      -2.766  27.947  25.892  1.00 12.01           O  
+ATOM    793  N   MET A 105      -3.906  29.119  24.313  1.00 13.56           N  
+ATOM    794  CA  MET A 105      -3.014  28.684  23.198  1.00  9.18           C  
+ATOM    795  C   MET A 105      -1.637  29.372  23.232  1.00  8.69           C  
+ATOM    796  O   MET A 105      -0.727  29.013  22.506  1.00  9.67           O  
+ATOM    797  CB  MET A 105      -3.739  28.882  21.838  1.00  3.51           C  
+ATOM    798  CG  MET A 105      -4.790  27.788  21.646  1.00  9.82           C  
+ATOM    799  SD  MET A 105      -5.184  27.455  19.852  1.00 12.90           S  
+ATOM    800  CE  MET A 105      -3.617  26.757  19.326  1.00  6.80           C  
+ATOM    801  N   ASN A 106      -1.509  30.373  24.105  1.00  7.08           N  
+ATOM    802  CA  ASN A 106      -0.270  31.037  24.269  1.00  4.32           C  
+ATOM    803  C   ASN A 106       0.809  30.046  24.765  1.00  8.04           C  
+ATOM    804  O   ASN A 106       2.030  30.336  24.608  1.00 11.37           O  
+ATOM    805  CB  ASN A 106      -0.396  32.190  25.241  1.00 12.62           C  
+ATOM    806  CG  ASN A 106      -1.239  33.309  24.682  1.00 16.51           C  
+ATOM    807  OD1 ASN A 106      -0.864  33.972  23.658  1.00  9.88           O  
+ATOM    808  ND2 ASN A 106      -2.372  33.492  25.355  1.00 15.30           N  
+ATOM    809  N   ALA A 107       0.360  28.870  25.250  1.00  8.10           N  
+ATOM    810  CA  ALA A 107       1.308  27.840  25.625  1.00 10.48           C  
+ATOM    811  C   ALA A 107       2.113  27.450  24.395  1.00 16.77           C  
+ATOM    812  O   ALA A 107       3.191  26.948  24.511  1.00 16.10           O  
+ATOM    813  CB  ALA A 107       0.585  26.599  26.143  1.00 11.40           C  
+ATOM    814  N   TRP A 108       1.577  27.639  23.205  1.00 10.51           N  
+ATOM    815  CA  TRP A 108       2.303  27.285  21.966  1.00  9.27           C  
+ATOM    816  C   TRP A 108       2.970  28.504  21.404  1.00  9.11           C  
+ATOM    817  O   TRP A 108       2.312  29.428  20.865  1.00  9.30           O  
+ATOM    818  CB  TRP A 108       1.398  26.569  20.912  1.00  4.39           C  
+ATOM    819  CG  TRP A 108       1.005  25.176  21.256  1.00  2.06           C  
+ATOM    820  CD1 TRP A 108       1.760  24.069  21.021  1.00 10.56           C  
+ATOM    821  CD2 TRP A 108      -0.146  24.722  21.926  1.00  4.61           C  
+ATOM    822  NE1 TRP A 108       1.131  22.972  21.471  1.00 11.23           N  
+ATOM    823  CE2 TRP A 108      -0.048  23.321  22.045  1.00 11.25           C  
+ATOM    824  CE3 TRP A 108      -1.256  25.348  22.436  1.00  8.16           C  
+ATOM    825  CZ2 TRP A 108      -1.038  22.520  22.626  1.00  7.13           C  
+ATOM    826  CZ3 TRP A 108      -2.220  24.549  23.074  1.00 13.29           C  
+ATOM    827  CH2 TRP A 108      -2.156  23.123  23.101  1.00  8.74           C  
+ATOM    828  N   VAL A 109       4.320  28.523  21.508  1.00 10.59           N  
+ATOM    829  CA  VAL A 109       5.046  29.672  21.044  1.00 10.72           C  
+ATOM    830  C   VAL A 109       4.800  30.025  19.545  1.00  7.07           C  
+ATOM    831  O   VAL A 109       4.617  31.199  19.228  1.00 12.32           O  
+ATOM    832  CB  VAL A 109       6.549  29.491  21.342  1.00 15.75           C  
+ATOM    833  CG1 VAL A 109       7.068  28.242  20.605  1.00 38.18           C  
+ATOM    834  CG2 VAL A 109       7.327  30.751  20.898  1.00 17.01           C  
+ATOM    835  N   ALA A 110       4.761  28.998  18.662  1.00  7.28           N  
+ATOM    836  CA  ALA A 110       4.506  29.281  17.232  1.00 14.92           C  
+ATOM    837  C   ALA A 110       3.122  29.845  17.031  1.00 12.74           C  
+ATOM    838  O   ALA A 110       2.902  30.659  16.125  1.00 13.19           O  
+ATOM    839  CB  ALA A 110       4.783  28.117  16.262  1.00 12.16           C  
+ATOM    840  N   TRP A 111       2.190  29.398  17.892  1.00  7.58           N  
+ATOM    841  CA  TRP A 111       0.821  29.901  17.789  1.00  5.91           C  
+ATOM    842  C   TRP A 111       0.815  31.399  18.100  1.00  9.06           C  
+ATOM    843  O   TRP A 111       0.249  32.308  17.369  1.00  6.22           O  
+ATOM    844  CB  TRP A 111      -0.240  29.136  18.618  1.00  6.54           C  
+ATOM    845  CG  TRP A 111      -1.589  29.763  18.461  1.00  9.13           C  
+ATOM    846  CD1 TRP A 111      -2.510  29.517  17.447  1.00  5.89           C  
+ATOM    847  CD2 TRP A 111      -2.190  30.781  19.295  1.00 10.48           C  
+ATOM    848  NE1 TRP A 111      -3.642  30.322  17.597  1.00  5.88           N  
+ATOM    849  CE2 TRP A 111      -3.471  31.090  18.728  1.00  5.72           C  
+ATOM    850  CE3 TRP A 111      -1.805  31.432  20.511  1.00  4.95           C  
+ATOM    851  CZ2 TRP A 111      -4.306  32.057  19.314  1.00 13.37           C  
+ATOM    852  CZ3 TRP A 111      -2.658  32.382  21.061  1.00  6.90           C  
+ATOM    853  CH2 TRP A 111      -3.906  32.666  20.489  1.00  4.12           C  
+ATOM    854  N   ARG A 112       1.497  31.701  19.218  1.00  7.90           N  
+ATOM    855  CA  ARG A 112       1.527  33.107  19.659  1.00 11.81           C  
+ATOM    856  C   ARG A 112       2.221  34.013  18.630  1.00  9.34           C  
+ATOM    857  O   ARG A 112       1.746  35.118  18.330  1.00  9.72           O  
+ATOM    858  CB  ARG A 112       2.215  33.175  21.040  1.00 18.21           C  
+ATOM    859  CG  ARG A 112       2.053  34.513  21.722  1.00 52.15           C  
+ATOM    860  CD  ARG A 112       2.813  34.593  23.056  1.00 27.12           C  
+ATOM    861  NE  ARG A 112       3.479  33.351  23.413  1.00 52.40           N  
+ATOM    862  CZ  ARG A 112       4.785  33.247  23.639  1.00 49.41           C  
+ATOM    863  NH1 ARG A 112       5.612  34.286  23.535  1.00 53.98           N  
+ATOM    864  NH2 ARG A 112       5.274  32.058  23.981  1.00 51.24           N  
+ATOM    865  N   ASN A 113       3.331  33.501  18.078  1.00  8.96           N  
+ATOM    866  CA  ASN A 113       4.132  34.283  17.152  1.00 15.60           C  
+ATOM    867  C   ASN A 113       3.657  34.303  15.695  1.00 17.72           C  
+ATOM    868  O   ASN A 113       3.919  35.261  14.974  1.00 16.73           O  
+ATOM    869  CB  ASN A 113       5.657  33.938  17.244  1.00  8.06           C  
+ATOM    870  CG  ASN A 113       6.192  34.297  18.636  1.00 11.97           C  
+ATOM    871  OD1 ASN A 113       5.714  35.228  19.278  1.00 19.44           O  
+ATOM    872  ND2 ASN A 113       7.179  33.595  19.091  1.00  9.04           N  
+ATOM    873  N   ARG A 114       2.964  33.273  15.287  1.00  7.06           N  
+ATOM    874  CA  ARG A 114       2.604  33.129  13.873  1.00 11.57           C  
+ATOM    875  C   ARG A 114       1.171  33.002  13.552  1.00 19.78           C  
+ATOM    876  O   ARG A 114       0.827  33.118  12.375  1.00 14.27           O  
+ATOM    877  CB  ARG A 114       3.309  31.830  13.395  1.00  8.51           C  
+ATOM    878  CG  ARG A 114       4.766  31.877  13.898  1.00 21.43           C  
+ATOM    879  CD  ARG A 114       5.833  31.132  13.125  1.00 27.54           C  
+ATOM    880  NE  ARG A 114       5.898  31.278  11.660  1.00 16.59           N  
+ATOM    881  CZ  ARG A 114       6.631  30.413  10.970  1.00 12.23           C  
+ATOM    882  NH1 ARG A 114       7.271  29.439  11.649  1.00 11.43           N  
+ATOM    883  NH2 ARG A 114       6.744  30.477   9.659  1.00 12.83           N  
+ATOM    884  N   CYS A 115       0.351  32.723  14.572  1.00  5.86           N  
+ATOM    885  CA  CYS A 115      -1.055  32.487  14.333  1.00  8.05           C  
+ATOM    886  C   CYS A 115      -1.937  33.541  14.914  1.00 18.18           C  
+ATOM    887  O   CYS A 115      -2.914  34.024  14.264  1.00 11.36           O  
+ATOM    888  CB  CYS A 115      -1.488  31.114  14.872  1.00  7.31           C  
+ATOM    889  SG  CYS A 115      -0.553  29.849  14.022  1.00 10.81           S  
+ATOM    890  N   LYS A 116      -1.630  33.796  16.196  1.00 10.46           N  
+ATOM    891  CA  LYS A 116      -2.372  34.723  16.976  1.00  9.75           C  
+ATOM    892  C   LYS A 116      -2.562  36.032  16.228  1.00  9.63           C  
+ATOM    893  O   LYS A 116      -1.583  36.599  15.729  1.00 13.85           O  
+ATOM    894  CB  LYS A 116      -1.716  34.948  18.335  1.00 12.72           C  
+ATOM    895  CG  LYS A 116      -2.557  35.791  19.284  1.00  7.87           C  
+ATOM    896  CD  LYS A 116      -1.809  35.938  20.635  1.00 15.62           C  
+ATOM    897  CE  LYS A 116      -2.607  36.597  21.773  1.00 17.04           C  
+ATOM    898  NZ  LYS A 116      -1.889  36.524  23.073  1.00 11.32           N  
+ATOM    899  N   GLY A 117      -3.862  36.462  16.131  1.00  9.19           N  
+ATOM    900  CA  GLY A 117      -4.213  37.737  15.493  1.00 22.87           C  
+ATOM    901  C   GLY A 117      -4.091  37.759  13.972  1.00 33.97           C  
+ATOM    902  O   GLY A 117      -4.044  38.799  13.371  1.00 28.79           O  
+ATOM    903  N   THR A 118      -4.019  36.612  13.340  1.00 15.57           N  
+ATOM    904  CA  THR A 118      -3.940  36.537  11.885  1.00 20.24           C  
+ATOM    905  C   THR A 118      -5.285  35.977  11.407  1.00 18.25           C  
+ATOM    906  O   THR A 118      -6.080  35.563  12.249  1.00 18.09           O  
+ATOM    907  CB  THR A 118      -2.747  35.680  11.439  1.00 13.62           C  
+ATOM    908  OG1 THR A 118      -3.060  34.321  11.639  1.00 12.88           O  
+ATOM    909  CG2 THR A 118      -1.455  36.072  12.193  1.00 12.89           C  
+ATOM    910  N   ASP A 119      -5.573  35.973  10.102  1.00 20.97           N  
+ATOM    911  CA  ASP A 119      -6.848  35.408   9.620  1.00 17.43           C  
+ATOM    912  C   ASP A 119      -6.693  33.892   9.567  1.00 19.50           C  
+ATOM    913  O   ASP A 119      -6.430  33.280   8.509  1.00 24.87           O  
+ATOM    914  CB  ASP A 119      -7.228  35.933   8.234  1.00 27.62           C  
+ATOM    915  CG  ASP A 119      -8.359  35.154   7.625  1.00 57.62           C  
+ATOM    916  OD1 ASP A 119      -9.168  34.529   8.288  1.00 36.72           O  
+ATOM    917  OD2 ASP A 119      -8.349  35.190   6.315  1.00 41.26           O  
+ATOM    918  N   VAL A 120      -6.836  33.291  10.750  1.00 20.10           N  
+ATOM    919  CA  VAL A 120      -6.637  31.835  10.895  1.00 24.77           C  
+ATOM    920  C   VAL A 120      -7.664  31.011  10.149  1.00 16.15           C  
+ATOM    921  O   VAL A 120      -7.486  29.777   9.914  1.00 13.85           O  
+ATOM    922  CB  VAL A 120      -6.476  31.372  12.367  1.00 15.61           C  
+ATOM    923  CG1 VAL A 120      -5.271  32.055  13.060  1.00 17.17           C  
+ATOM    924  CG2 VAL A 120      -7.761  31.691  13.097  1.00 18.96           C  
+ATOM    925  N   GLN A 121      -8.761  31.679   9.776  1.00 18.05           N  
+ATOM    926  CA  GLN A 121      -9.808  30.981   9.039  1.00 20.34           C  
+ATOM    927  C   GLN A 121      -9.285  30.499   7.694  1.00 14.19           C  
+ATOM    928  O   GLN A 121      -9.831  29.566   7.093  1.00 15.61           O  
+ATOM    929  CB  GLN A 121     -10.896  31.993   8.746  1.00 39.58           C  
+ATOM    930  CG  GLN A 121     -12.076  31.743   9.628  1.00 39.30           C  
+ATOM    931  CD  GLN A 121     -13.286  31.887   8.785  1.00 58.93           C  
+ATOM    932  OE1 GLN A 121     -13.734  30.908   8.174  1.00 64.91           O  
+ATOM    933  NE2 GLN A 121     -13.757  33.131   8.683  1.00 55.29           N  
+ATOM    934  N   ALA A 122      -8.222  31.161   7.229  1.00 14.53           N  
+ATOM    935  CA  ALA A 122      -7.588  30.777   5.964  1.00 13.31           C  
+ATOM    936  C   ALA A 122      -7.152  29.312   5.955  1.00 18.32           C  
+ATOM    937  O   ALA A 122      -7.123  28.622   4.924  1.00 14.96           O  
+ATOM    938  CB  ALA A 122      -6.378  31.657   5.724  1.00 18.92           C  
+ATOM    939  N   TRP A 123      -6.792  28.829   7.138  1.00 14.16           N  
+ATOM    940  CA  TRP A 123      -6.304  27.460   7.305  1.00 21.27           C  
+ATOM    941  C   TRP A 123      -7.326  26.369   7.031  1.00 12.05           C  
+ATOM    942  O   TRP A 123      -6.976  25.209   6.736  1.00 15.94           O  
+ATOM    943  CB  TRP A 123      -5.545  27.274   8.649  1.00 14.43           C  
+ATOM    944  CG  TRP A 123      -4.302  28.098   8.663  1.00 16.32           C  
+ATOM    945  CD1 TRP A 123      -4.115  29.310   9.238  1.00 16.23           C  
+ATOM    946  CD2 TRP A 123      -3.066  27.733   8.045  1.00  6.26           C  
+ATOM    947  NE1 TRP A 123      -2.826  29.737   8.996  1.00 13.70           N  
+ATOM    948  CE2 TRP A 123      -2.184  28.799   8.248  1.00 10.20           C  
+ATOM    949  CE3 TRP A 123      -2.680  26.618   7.323  1.00 14.76           C  
+ATOM    950  CZ2 TRP A 123      -0.873  28.742   7.761  1.00 21.80           C  
+ATOM    951  CZ3 TRP A 123      -1.413  26.574   6.804  1.00 21.47           C  
+ATOM    952  CH2 TRP A 123      -0.520  27.623   7.023  1.00 22.40           C  
+ATOM    953  N   ILE A 124      -8.590  26.696   7.126  1.00 10.36           N  
+ATOM    954  CA  ILE A 124      -9.573  25.659   6.831  1.00 14.89           C  
+ATOM    955  C   ILE A 124     -10.353  25.927   5.530  1.00 16.52           C  
+ATOM    956  O   ILE A 124     -11.277  25.213   5.172  1.00 16.40           O  
+ATOM    957  CB  ILE A 124     -10.480  25.421   8.019  1.00 15.33           C  
+ATOM    958  CG1 ILE A 124     -11.016  26.778   8.456  1.00 15.55           C  
+ATOM    959  CG2 ILE A 124      -9.624  24.846   9.164  1.00 15.50           C  
+ATOM    960  CD1 ILE A 124     -12.489  26.742   8.908  1.00 32.95           C  
+ATOM    961  N   ARG A 125      -9.977  27.003   4.848  1.00 17.59           N  
+ATOM    962  CA  ARG A 125     -10.598  27.366   3.586  1.00 26.87           C  
+ATOM    963  C   ARG A 125     -10.424  26.259   2.569  1.00 18.05           C  
+ATOM    964  O   ARG A 125      -9.339  25.658   2.433  1.00 24.03           O  
+ATOM    965  CB  ARG A 125     -10.123  28.708   3.068  1.00 29.23           C  
+ATOM    966  CG  ARG A 125     -10.586  29.089   1.669  1.00 46.98           C  
+ATOM    967  CD  ARG A 125     -10.321  30.571   1.370  1.00 51.79           C  
+ATOM    968  NE  ARG A 125      -8.921  30.857   1.669  1.00 80.40           N  
+ATOM    969  CZ  ARG A 125      -7.924  30.424   0.892  1.00 80.57           C  
+ATOM    970  NH1 ARG A 125      -8.167  29.752  -0.234  1.00 50.97           N  
+ATOM    971  NH2 ARG A 125      -6.657  30.677   1.239  1.00 73.99           N  
+ATOM    972  N   GLY A 126     -11.581  25.957   1.917  1.00 23.54           N  
+ATOM    973  CA  GLY A 126     -11.741  24.959   0.858  1.00 15.85           C  
+ATOM    974  C   GLY A 126     -11.903  23.570   1.356  1.00 22.07           C  
+ATOM    975  O   GLY A 126     -11.988  22.638   0.564  1.00 33.97           O  
+ATOM    976  N   CYS A 127     -11.912  23.409   2.685  1.00 12.41           N  
+ATOM    977  CA  CYS A 127     -12.009  22.059   3.164  1.00 10.52           C  
+ATOM    978  C   CYS A 127     -13.442  21.578   3.291  1.00 13.96           C  
+ATOM    979  O   CYS A 127     -14.383  22.316   3.676  1.00 19.22           O  
+ATOM    980  CB  CYS A 127     -11.259  21.795   4.516  1.00 16.08           C  
+ATOM    981  SG  CYS A 127      -9.562  22.365   4.503  1.00 17.92           S  
+ATOM    982  N   ARG A 128     -13.609  20.299   3.023  1.00 19.23           N  
+ATOM    983  CA  ARG A 128     -14.929  19.757   3.200  1.00 29.52           C  
+ATOM    984  C   ARG A 128     -15.116  19.387   4.645  1.00 19.23           C  
+ATOM    985  O   ARG A 128     -14.626  18.345   5.078  1.00 29.24           O  
+ATOM    986  CB  ARG A 128     -15.159  18.511   2.363  1.00 35.15           C  
+ATOM    987  CG  ARG A 128     -16.602  18.043   2.481  1.00 32.92           C  
+ATOM    988  CD  ARG A 128     -16.961  17.187   1.277  1.00 38.70           C  
+ATOM    989  NE  ARG A 128     -15.779  16.498   0.721  1.00 50.55           N  
+ATOM    990  CZ  ARG A 128     -15.503  16.208  -0.581  1.00 55.70           C  
+ATOM    991  NH1 ARG A 128     -16.293  16.551  -1.610  1.00 46.94           N  
+ATOM    992  NH2 ARG A 128     -14.377  15.541  -0.856  1.00 48.25           N  
+ATOM    993  N   LEU A 129     -15.775  20.226   5.404  1.00 22.75           N  
+ATOM    994  CA  LEU A 129     -15.976  19.869   6.811  1.00 33.38           C  
+ATOM    995  C   LEU A 129     -17.449  19.906   7.141  1.00 72.70           C  
+ATOM    996  O   LEU A 129     -18.191  20.465   6.277  1.00 49.87           O  
+ATOM    997  CB  LEU A 129     -15.235  20.742   7.845  1.00 23.67           C  
+ATOM    998  CG  LEU A 129     -13.711  20.917   7.641  1.00 28.34           C  
+ATOM    999  CD1 LEU A 129     -13.308  22.315   8.150  1.00 36.38           C  
+ATOM   1000  CD2 LEU A 129     -12.970  19.868   8.434  1.00 43.93           C  
+ATOM   1001  OXT LEU A 129     -17.769  19.416   8.251  1.00 70.56           O  
+TER    1002      LEU A 129                                                      
+HETATM 1003  O   HOH A 131      10.467  23.310  29.307  1.00 39.80           O  
+HETATM 1004  O   HOH A 132      -1.176  15.339   1.263  1.00 49.26           O  
+HETATM 1005  O   HOH A 133      -2.951  23.272   0.888  1.00 44.65           O  
+HETATM 1006  O   HOH A 134       1.217  11.752  36.245  1.00 47.43           O  
+HETATM 1007  O   HOH A 135      -5.565  19.565   2.145  1.00 30.47           O  
+HETATM 1008  O   HOH A 136      -8.561  15.857   2.186  1.00 67.45           O  
+HETATM 1009  O   HOH A 137     -11.371  18.534   1.797  1.00 29.55           O  
+HETATM 1010  O   HOH A 138      -5.769  17.371   2.752  1.00 20.51           O  
+HETATM 1011  O   HOH A 139      -1.154  20.600   3.261  1.00 38.26           O  
+HETATM 1012  O   HOH A 140     -14.391  27.317   2.971  1.00 41.99           O  
+HETATM 1013  O   HOH A 141       9.925  21.314   4.349  1.00 72.67           O  
+HETATM 1014  O   HOH A 142      -3.255  29.381   4.245  1.00 58.91           O  
+HETATM 1015  O   HOH A 143      -1.469  12.396   4.494  1.00 45.35           O  
+HETATM 1016  O   HOH A 144       1.369  18.410   4.770  1.00 33.99           O  
+HETATM 1017  O   HOH A 145     -13.995  24.766   5.080  1.00 22.81           O  
+HETATM 1018  O   HOH A 146     -11.877  17.908   5.201  1.00 33.63           O  
+HETATM 1019  O   HOH A 147       3.579  19.755   5.269  1.00 28.71           O  
+HETATM 1020  O   HOH A 148      -0.938  23.757   3.720  1.00 71.21           O  
+HETATM 1021  O   HOH A 149       2.851  10.418   5.675  1.00 22.01           O  
+HETATM 1022  O   HOH A 150       6.153  10.387   6.792  1.00 23.16           O  
+HETATM 1023  O   HOH A 151      -4.154  33.433   7.551  1.00 36.56           O  
+HETATM 1024  O   HOH A 152      -2.892  31.523   5.422  1.00 70.64           O  
+HETATM 1025  O   HOH A 153       8.184  17.799   8.234  1.00 52.27           O  
+HETATM 1026  O   HOH A 154       7.851  28.286   8.261  1.00 20.33           O  
+HETATM 1027  O   HOH A 155      -0.327  32.726   8.576  1.00 42.08           O  
+HETATM 1028  O   HOH A 156      -7.096  11.131   8.405  1.00 40.02           O  
+HETATM 1029  O   HOH A 157      -3.462  37.549   8.393  1.00 46.77           O  
+HETATM 1030  O   HOH A 158      -8.809  13.307   8.142  1.00 30.47           O  
+HETATM 1031  O   HOH A 159      -0.082  35.568   8.883  1.00 34.44           O  
+HETATM 1032  O   HOH A 160       5.759  11.110   9.448  1.00 12.55           O  
+HETATM 1033  O   HOH A 161       1.655  33.826   9.694  1.00 24.07           O  
+HETATM 1034  O   HOH A 162      -2.547  32.477   9.746  1.00 26.29           O  
+HETATM 1035  O   HOH A 163       4.474  33.152   9.881  1.00 17.58           O  
+HETATM 1036  O   HOH A 164       3.338   7.494  10.654  1.00 33.32           O  
+HETATM 1037  O   HOH A 165       8.193  18.034  10.710  1.00 21.87           O  
+HETATM 1038  O   HOH A 166       7.329  25.034  11.046  1.00 35.50           O  
+HETATM 1039  O   HOH A 167     -14.609  15.459  10.822  1.00 40.68           O  
+HETATM 1040  O   HOH A 168     -10.475  34.131  10.612  1.00 52.70           O  
+HETATM 1041  O   HOH A 169       2.254   4.105  11.205  1.00 64.88           O  
+HETATM 1042  O   HOH A 170       8.719  22.583  10.964  1.00 48.95           O  
+HETATM 1043  O   HOH A 171     -11.115  29.055  11.946  1.00 14.76           O  
+HETATM 1044  O   HOH A 172     -13.874  27.050  11.990  1.00 53.84           O  
+HETATM 1045  O   HOH A 173      -5.674  10.727  13.313  1.00 39.68           O  
+HETATM 1046  O   HOH A 174     -11.999  31.072  12.630  1.00 63.32           O  
+HETATM 1047  O   HOH A 175     -17.134  26.536  21.794  1.00 62.44           O  
+HETATM 1048  O   HOH A 176      10.318  19.087  12.648  1.00 26.21           O  
+HETATM 1049  O   HOH A 177      -6.214   5.635  13.140  1.00 68.62           O  
+HETATM 1050  O   HOH A 178       4.038   7.633  13.524  1.00 23.33           O  
+HETATM 1051  O   HOH A 179      -3.450   4.975  13.407  1.00 49.46           O  
+HETATM 1052  O   HOH A 180      -7.339  10.569  14.831  1.00 42.40           O  
+HETATM 1053  O   HOH A 181       7.627  28.588  14.215  1.00 19.60           O  
+HETATM 1054  O   HOH A 182       1.193   5.002  14.601  1.00 41.13           O  
+HETATM 1055  O   HOH A 183      -8.623   6.412  17.116  1.00 59.00           O  
+HETATM 1056  O   HOH A 184       9.260  21.322  13.868  1.00 48.09           O  
+HETATM 1057  O   HOH A 185     -16.033  21.080  23.763  1.00 60.47           O  
+HETATM 1058  O   HOH A 186      11.590  13.479  14.940  1.00 13.69           O  
+HETATM 1059  O   HOH A 187      -6.668  35.428  15.178  1.00 31.78           O  
+HETATM 1060  O   HOH A 188      -4.892  -0.201  15.033  1.00 72.09           O  
+HETATM 1061  O   HOH A 189       1.858  30.674   4.862  1.00 56.21           O  
+HETATM 1062  O   HOH A 190     -10.895  36.814  14.982  1.00 35.20           O  
+HETATM 1063  O   HOH A 191       0.992  36.275  15.433  1.00 18.46           O  
+HETATM 1064  O   HOH A 192       4.392   4.463  15.873  1.00 37.98           O  
+HETATM 1065  O   HOH A 193      -9.880  33.178  15.826  1.00 28.17           O  
+HETATM 1066  O   HOH A 194       9.025  23.955  15.613  1.00 37.22           O  
+HETATM 1067  O   HOH A 195      -7.206  38.395  16.256  1.00 55.89           O  
+HETATM 1068  O   HOH A 196      -0.377  36.589  25.905  1.00 34.65           O  
+HETATM 1069  O   HOH A 197     -14.982  19.034  22.737  1.00 64.15           O  
+HETATM 1070  O   HOH A 198      -0.223  12.099  16.607  1.00 28.04           O  
+HETATM 1071  O   HOH A 199      -6.317  33.838  16.796  1.00 22.79           O  
+HETATM 1072  O   HOH A 200       8.078  31.375  16.915  1.00 10.01           O  
+HETATM 1073  O   HOH A 201       1.489  13.820  17.020  1.00 21.39           O  
+HETATM 1074  O   HOH A 202       9.131  28.844  17.354  1.00 52.49           O  
+HETATM 1075  O   HOH A 203      14.994  15.102  18.263  1.00 53.36           O  
+HETATM 1076  O   HOH A 204      15.333  22.227  18.703  1.00 50.97           O  
+HETATM 1077  O   HOH A 205      16.093  18.390  18.034  1.00 33.35           O  
+HETATM 1078  O   HOH A 206       3.768   6.469  18.636  1.00 38.13           O  
+HETATM 1079  O   HOH A 207     -13.347  18.342  27.796  1.00 58.07           O  
+HETATM 1080  O   HOH A 208     -14.200   9.443  18.914  1.00 81.98           O  
+HETATM 1081  O   HOH A 209       9.257  22.574  18.988  1.00 22.39           O  
+HETATM 1082  O   HOH A 210       4.907  37.823  19.024  1.00 41.16           O  
+HETATM 1083  O   HOH A 211      -1.433   4.723  19.249  1.00 62.14           O  
+HETATM 1084  O   HOH A 212      -1.071  11.315  19.089  1.00 15.91           O  
+HETATM 1085  O   HOH A 213      -3.235   8.498  19.677  1.00 21.40           O  
+HETATM 1086  O   HOH A 214       7.620  25.081  19.861  1.00 35.14           O  
+HETATM 1087  O   HOH A 215       1.711  16.542  19.779  1.00  9.12           O  
+HETATM 1088  O   HOH A 216      11.204  23.310  20.531  1.00 44.08           O  
+HETATM 1089  O   HOH A 217      -0.792   7.051  20.523  1.00 25.44           O  
+HETATM 1090  O   HOH A 219     -11.306  12.254  20.909  1.00 58.87           O  
+HETATM 1091  O   HOH A 220     -15.497  22.071  20.968  1.00 42.59           O  
+HETATM 1092  O   HOH A 221     -14.046  13.904  22.148  1.00 59.61           O  
+HETATM 1093  O   HOH A 222       5.919  23.529  21.973  1.00 36.31           O  
+HETATM 1094  O   HOH A 223       5.611  26.207  22.382  1.00 26.89           O  
+HETATM 1095  O   HOH A 224       8.793  23.775  23.737  1.00 53.46           O  
+HETATM 1096  O   HOH A 225     -14.958  24.195  25.086  1.00 26.18           O  
+HETATM 1097  O   HOH A 226     -14.258  17.077  24.576  1.00 42.15           O  
+HETATM 1098  O   HOH A 227       3.901  21.949  25.503  1.00 15.15           O  
+HETATM 1099  O   HOH A 228     -17.138  15.370  26.017  1.00 64.87           O  
+HETATM 1100  O   HOH A 229       1.041  39.543  25.118  1.00 75.63           O  
+HETATM 1101  O   HOH A 230     -18.171  19.097  19.147  1.00 58.24           O  
+HETATM 1102  O   HOH A 231      19.800  18.720  25.766  1.00 41.96           O  
+HETATM 1103  O   HOH A 232      13.910  14.986  26.681  1.00 11.69           O  
+HETATM 1104  O   HOH A 233       4.284  26.127  26.885  1.00 44.36           O  
+HETATM 1105  O   HOH A 234      14.969  25.124  27.122  1.00 37.22           O  
+HETATM 1106  O   HOH A 235      19.235  28.375  27.869  1.00 51.94           O  
+HETATM 1107  O   HOH A 236      -8.227  15.787  27.736  1.00 28.71           O  
+HETATM 1108  O   HOH A 237      11.129  29.398  26.784  1.00 53.97           O  
+HETATM 1109  O   HOH A 238      -2.152  26.984  28.613  1.00 25.16           O  
+HETATM 1110  O   HOH A 239     -12.126  14.584  29.332  1.00 70.39           O  
+HETATM 1111  O   HOH A 240      -6.410  28.639  29.739  1.00 33.78           O  
+HETATM 1112  O   HOH A 241      -9.363  18.929  29.236  1.00 54.93           O  
+HETATM 1113  O   HOH A 242       7.290   6.035  29.744  1.00 44.70           O  
+HETATM 1114  O   HOH A 243       0.532   4.323  25.856  1.00 66.97           O  
+HETATM 1115  O   HOH A 244      -5.527  11.769  31.278  1.00 52.96           O  
+HETATM 1116  O   HOH A 245       9.709  13.211  30.865  1.00 15.87           O  
+HETATM 1117  O   HOH A 246      -5.539  14.098  29.938  1.00 63.37           O  
+HETATM 1118  O   HOH A 247       2.285   7.164  31.744  1.00 42.72           O  
+HETATM 1119  O   HOH A 249       2.557  37.778  32.502  1.00 60.66           O  
+HETATM 1120  O   HOH A 250      11.653  11.933  32.683  1.00 24.19           O  
+HETATM 1121  O   HOH A 251      -2.007   6.140  23.286  1.00 48.50           O  
+HETATM 1122  O   HOH A 252       7.578  12.160  33.759  1.00 39.59           O  
+HETATM 1123  O   HOH A 253      14.454   7.531  33.771  1.00 35.83           O  
+HETATM 1124  O   HOH A 254      -3.513  31.619  34.652  1.00 56.09           O  
+HETATM 1125  O   HOH A 255      13.552  10.709  34.982  1.00 58.90           O  
+HETATM 1126  O   HOH A 256      -0.456  24.995  36.970  1.00 68.09           O  
+HETATM 1127  O   HOH A 257      -2.238   9.934   2.797  1.00 67.44           O  
+HETATM 1128  O   HOH A 258      -7.483  20.739  37.397  1.00 68.20           O  
+HETATM 1129  O   HOH A 259      16.885  30.334  28.147  1.00 50.66           O  
+HETATM 1130  O   HOH A 260      -2.189  19.144   1.123  1.00 56.23           O  
+HETATM 1131  O   HOH A 263       5.554  35.805  21.621  1.00 47.47           O  
+HETATM 1132  O   HOH A 264       0.167  38.321  22.074  1.00 63.57           O  
+HETATM 1133  O   HOH A 265       2.643  23.311  24.222  1.00 37.06           O  
+HETATM 1134  O   HOH A 266      -3.261  12.368  26.079  1.00 36.01           O  
+HETATM 1135  O   HOH A 267      -8.163  28.523  28.227  1.00 31.53           O  
+HETATM 1136  O   HOH A 268      11.314  34.308  29.649  1.00 69.35           O  
+HETATM 1137  O   HOH A 269      -8.925  18.710  -0.425  1.00 67.80           O  
+HETATM 1138  O   HOH A 270       1.106   7.975   2.503  1.00 57.87           O  
+HETATM 1139  O   HOH A 271       3.658  14.557   2.346  1.00 58.10           O  
+HETATM 1140  O   HOH A 272       5.462  18.910   4.058  1.00 56.45           O  
+HETATM 1141  O   HOH A 273     -12.194  34.778   7.299  1.00 56.09           O  
+HETATM 1142  O   HOH A 274      -1.696   6.065   8.495  1.00 68.76           O  
+HETATM 1143  O   HOH A 275     -12.182  12.057   9.624  0.50 89.37           O  
+HETATM 1144  O   HOH A 276     -17.165  32.342   9.988  1.00 67.99           O  
+HETATM 1145  O   HOH A 277      -0.310   4.774   9.964  1.00 51.58           O  
+HETATM 1146  O   HOH A 278     -18.106   6.723  19.155  1.00 64.11           O  
+HETATM 1147  O   HOH A 279     -10.523   7.855  18.757  1.00 55.12           O  
+HETATM 1148  O   HOH A 280      -5.786   9.627  24.788  1.00 56.60           O  
+HETATM 1149  O   HOH A 281       4.973  30.366  26.631  1.00 56.27           O  
+HETATM 1150  O   HOH A 282     -14.163  23.294  27.041  1.00 80.21           O  
+HETATM 1151  O   HOH A 283       4.190  23.920  28.202  1.00 47.07           O  
+HETATM 1152  O   HOH A 284       1.927  24.235  28.261  1.00 53.05           O  
+HETATM 1153  O   HOH A 285       8.469  24.914  28.323  1.00 76.29           O  
+HETATM 1154  O   HOH A 286       0.504  26.234  30.223  1.00 48.47           O  
+HETATM 1155  O   HOH A 287       4.961   6.376  30.326  1.00 57.17           O  
+HETATM 1156  O   HOH A 288      -9.395  28.233  30.605  1.00 55.86           O  
+HETATM 1157  O   HOH A 289      -7.403  29.010  31.768  1.00 58.13           O  
+HETATM 1158  O   HOH A 290      17.262  22.252  32.977  1.00 32.13           O  
+HETATM 1159  O   HOH A 291     -13.958  24.749  32.936  1.00 40.16           O  
+HETATM 1160  O   HOH A 292      11.050   6.576  33.893  1.00 53.38           O  
+HETATM 1161  O   HOH A 293      -6.940  30.679  34.967  1.00 57.95           O  
+HETATM 1162  O   HOH A 294      -7.751  19.631  32.932  1.00 55.95           O  
+HETATM 1163  O   HOH A 295     -11.917  25.473  35.232  1.00 70.62           O  
+HETATM 1164  O   HOH A 296      -0.614  22.162  37.001  1.00 49.79           O  
+HETATM 1165  O   HOH A 297      -5.763  25.243  36.097  1.00 78.09           O  
+HETATM 1166  O   HOH A 298      -0.024  14.493  36.828  1.00 63.91           O  
+HETATM 1167  O   HOH A 299       0.443  17.296   2.028  1.00 52.55           O  
+HETATM 1168  O   HOH A 300       1.738  27.507   3.463  1.00 74.82           O  
+HETATM 1169  O   HOH A 301       3.836  11.760   3.259  1.00 57.42           O  
+HETATM 1170  O   HOH A 302      -9.211   4.115  14.687  1.00 48.13           O  
+HETATM 1171  O   HOH A 303      16.205  21.210  16.009  1.00 69.59           O  
+HETATM 1172  O   HOH A 304     -14.845   6.428  21.717  1.00 61.77           O  
+HETATM 1173  O   HOH A 305     -13.311   8.488  24.665  1.00 62.09           O  
+HETATM 1174  O   HOH A 306       8.880  27.820  26.816  1.00 71.28           O  
+HETATM 1175  O   HOH A 307       0.932  10.327   2.387  1.00 62.28           O  
+HETATM 1176  O   HOH A 308     -32.793   6.518  16.878  1.00 55.27           O  
+HETATM 1177  O   HOH A 309     -10.109  33.422   4.951  1.00 51.37           O  
+HETATM 1178  O   HOH A 310      -6.930  35.720   3.927  1.00 68.08           O  
+HETATM 1179  O   HOH A 311      -1.458  29.021  31.741  1.00 71.39           O  
+HETATM 1180  O   HOH A 312      -7.776  27.408  33.976  1.00 51.50           O  
+HETATM 1181  O   HOH A 313       2.002  13.196   3.708  1.00 54.99           O  
+HETATM 1182  O   HOH A 314       7.005  28.792  27.719  1.00 69.52           O  
+HETATM 1183  O   HOH A 315     -14.736  20.042  16.788  1.00 37.49           O  
+HETATM 1184  O   HOH A 316      17.457  15.414  26.607  1.00 36.58           O  
+HETATM 1185  O   HOH A 317       1.388  37.676  19.438  1.00 42.27           O  
+HETATM 1186  O   HOH A 318      12.884  12.733  37.805  0.50 65.31           O  
+HETATM 1187  O   HOH A 319       7.795  26.278  15.645  1.00 44.16           O  
+CONECT   48  981                                                                
+CONECT  238  889                                                                
+CONECT  513  630                                                                
+CONECT  601  724                                                                
+CONECT  630  513                                                                
+CONECT  724  601                                                                
+CONECT  889  238                                                                
+CONECT  981   48                                                                
+MASTER      271    0    0    7    3    0    0    6 1186    1    8   10          
+END                                                                             

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/clean.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wd=`pwd`
+
+echo "This will delete your output data in ${wd}"
+read -p "Do you want to proceed? (y/n) " yn
+
+case $yn in
+        y ) echo ok, we will proceed;;
+        n ) echo exiting...;
+                exit;;
+        * ) echo invalid response;
+                exit 1;;
+esac
+
+rm *gro *top *itp *tpr mdout.mdp

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/em.mdp
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/em.mdp
@@ -1,0 +1,31 @@
+;
+;	User spoel (236)
+;	Wed Nov  3 17:12:44 1993
+;	Input file
+;
+constraints         =  none
+define              =  -DFLEXIBLE
+integrator          =  steep
+nsteps              =  1000
+nstxout             =  50
+;
+;	Energy minimizing stuff
+;
+emtol               =  1000
+emstep              =  0.01
+
+nstcomm             =  1
+nstcalcenergy       =  1
+
+coulombtype         =  PME
+rvdw                =  0.9
+rlist               =  0.9 
+rcoulomb            =  0.9
+fourierspacing      =  0.12
+pme_order           =  4
+ewald_rtol          =  1e-5
+
+Tcoupl              =  no
+Pcoupl              =  no
+gen_vel             =  no
+

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/00-prep/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#BEGIN INPUT
+gmx=gmx_plumed
+pdb=1hel.pdb
+ff=6 #Option 6 corresponds to AMBER99sb-ILDN
+wat=1 #Option 1 corresponds to tip3p
+box=9.3 #Default box size
+salt=0.15 #Default salt concentration
+ionGrp=13
+#END INPUT
+
+#Generate first topology file (protein + crystal water/ions)
+$gmx pdb2gmx -f ${pdb} -p topol_prot.top -o prot.gro << STOP
+${ff}
+${wat}
+STOP
+
+#Define simulation box for preiodic boundary conditions (PBC)
+$gmx editconf -f prot.gro -box ${box} -o box.gro
+
+#Make copy of protein topology file and delete crystal water/ions from original
+cp topol_prot.top topol.top
+awk '{if($1!="SOL"&&$1!="NA"&&$1!="CL") {printf("%s\n",$0);}}' topol.top >& topol_prot.top
+
+#Solvate the protein and update new topology file (keep crystal water/ions)
+$gmx solvate -cp box.gro -cs -p -o solv.gro
+rm \#topol.top.1\#
+
+#Add ions to the solution (requires *.tpr input file)
+$gmx grompp -f em.mdp -c solv.gro -p -o tmp.tpr -maxwarn 1
+$gmx genion -s tmp.tpr -p -o prep.gro -neutral -conc ${salt} << STOP
+${ionGrp}
+STOP
+rm \#topol.top.1\#

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/clean.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wd=`pwd`
+
+echo "This will delete your output data in ${wd}"
+read -p "Do you want to proceed? (y/n) " yn
+
+case $yn in
+        y ) echo ok, we will proceed;;
+        n ) echo exiting...;
+                exit;;
+        * ) echo invalid response;
+                exit 1;;
+esac
+
+rm -r em equi slurm-*.out

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/em.mdp
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/em.mdp
@@ -1,0 +1,31 @@
+;
+;	User spoel (236)
+;	Wed Nov  3 17:12:44 1993
+;	Input file
+;
+constraints         =  none
+define              =  -DFLEXIBLE -DPOSRES
+integrator          =  steep
+nsteps              =  1000
+nstxout             =  50
+;
+;	Energy minimizing stuff
+;
+emtol               =  1000
+emstep              =  0.01
+
+nstcomm             =  1
+nstcalcenergy       =  1
+
+coulombtype         =  PME
+rvdw                =  0.9
+rlist               =  0.9 
+rcoulomb            =  0.9
+fourierspacing      =  0.12
+pme_order           =  4
+ewald_rtol          =  1e-5
+
+Tcoupl              =  no
+Pcoupl              =  no
+gen_vel             =  no
+

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/equi.mdp
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/equi.mdp
@@ -1,0 +1,48 @@
+define                  = -DPOSRES  ; make sure this is set in your topology
+; Run parameters
+integrator              = md        ; leap-frog integrator
+nsteps                  = 100000    ; 1.0 * 100000 = 100 ps
+dt                      = 0.001    ; 1 fs
+; Output control
+nstxout                 = 1000      ; save coordinates every 1 ps
+nstvout                 = 1000      ; save velocities every 1 ps
+nstenergy               = 1000      ; save energies every 1 ps
+nstlog                  = 1000      ; update log file every 1 ps
+; Center of mass (COM) motion
+nstcomm                 = 100       ; remove COM motion every 100 steps
+comm-mode               = Linear    ; remove only COM translation
+; Bond parameters
+continuation            = no        ; first dynamics run
+constraint_algorithm    = lincs     ; holonomic constraints
+constraints             = h-bonds   ; constrain bonds with hydrogens
+lincs_iter              = 1         ; accuracy of LINCS
+lincs_order             = 4         ; also related to accuracy
+; Nonbonded settings
+cutoff-scheme           = Verlet    ; Buffered neighbor searching
+nstlist                 = 10        ; 10 fs, largely irrelevant with Verlet
+rcoulomb                = 1.0       ; short-range electrostatic cutoff (in nm)
+rvdw                    = 1.0       ; short-range van der Waals cutoff (in nm)
+DispCorr                = EnerPres  ; account for cut-off vdW scheme
+; Electrostatics
+coulombtype             = PME       ; Particle Mesh Ewald for long-range electrostatics
+pme_order               = 4         ; cubic interpolation
+fourierspacing          = 0.12      ; grid spacing for FFT
+; Temperature coupling is on
+tcoupl                  = v-rescale ; fast relaation thermostat
+; we define separate thermostats for the solute and solvent (need to adapt)
+; see default groups defined by Gromacs for your system or define your own (make_ndx)
+tc-grps                 = Protein  non-Protein ; the separate groups for the thermostats
+tau-t                   = 1.0      1.0     ; time constants for thermostats (ps)
+ref-t                   = 300      300     ; reference temperature for thermostats (K)
+; Pressure coupling is off
+pcoupl                  = C-rescale ; fast relaxation barostat
+tau-p                   = 2.0       ; time constant for barostat (ps)
+compressibility         = 4.5e-5    ; compressibility (1/bar) set to water at ~300K
+ref-p                   = 1.0       ; reference pressure for barostat (bar)
+refcoord_scaling        = com       ; scale COM of position restraint reference
+; Periodic boundary conditions
+pbc                     = xyz       ; 3-D PBC
+; Velocity generation
+gen_vel                 = yes       ; assign velocities from Maxwell distribution
+gen_temp                = 300       ; temperature for Maxwell distribution
+gen_seed                = -1        ; generate a random seed

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/01-em+equi/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#SBATCH -p general
+#SBATCH -G a100:1
+#SBATCH -N 1
+#SBATCH -c 12
+#SBATCH -t 0-04:00                  # wall time (D-HH:MM)
+#SBATCH -J EMEQUI
+
+#BEGIN INPUT
+inpTOP=../00-prep/topol.top
+inpGRO=../00-prep/prep.gro
+next=1
+nextDir=../02-MD
+gmx=gmx_plumed
+#END INPUT
+
+files=(
+em.mdp
+equi.mdp
+${inpTOP}
+${inpGRO}
+)
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+#Run energy minimization of the freshly solvated protein
+if [ ! -d em ]; then
+mkdir em
+fi
+cd em
+$gmx grompp -f ../em.mdp -c ../${inpGRO} -p ../${inpTOP} -r ../${inpGRO} -o em.tpr >& grompp.out
+$gmx mdrun -v -deffnm em -cpi -nt 1 -pin on >& mdrun.out
+cd ..
+
+#Run equilibration MD simulation with position restraints on heavy protein atoms
+if [ ! -d equi ]; then
+mkdir equi
+fi
+cd equi
+$gmx grompp -f ../equi.mdp -c ../em/em.gro -p ../${inpTOP} -r ../${inpGRO} -o equi.tpr >& grompp.out
+$gmx mdrun -v -deffnm equi -cpi >& mdrun.out
+cd ..
+
+#Start next part of the project if next=1
+if [ ${next} -eq 1 ]; then
+  if [ -f equi/equi.gro ]; then
+    if [ -d ${nextDir} ]; then
+      curDir=`pwd`
+      cd ${nextDir}
+      if [ -f run.sh ]; then
+        sbatch run.sh
+      fi
+      cd ${curDir}
+    fi
+  fi
+fi

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/02-MD/clean.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/02-MD/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wd=`pwd`
+
+echo "This will delete your output data in ${wd}"
+read -p "Do you want to proceed? (y/n) " yn
+
+case $yn in
+        y ) echo ok, we will proceed;;
+        n ) echo exiting...;
+                exit;;
+        * ) echo invalid response;
+                exit 1;;
+esac
+
+rm grompp.out mdrun.out mdout.mdp sample-NPT.edr sample-NPT.log sample-NPT.tpr sample-NPT.trr slurm-*.out

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/02-MD/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/02-MD/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#SBATCH -p general
+#SBATCH -G a100:1
+#SBATCH -N 1
+#SBATCH -c 12
+#SBATCH -t 0-12:00                  # wall time (D-HH:MM)
+#SBATCH -J SAMPLE
+
+#BEGIN INPUT
+inpTOP=../00-prep/topol.top
+inpGRO=../01-em+equi/equi/equi.gro
+next=1
+nextDir=../03-CG
+gmx=gmx_plumed
+#END INPUT
+
+files=(
+sample-NPT.mdp
+${inpTOP}
+${inptGRO}
+)
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+#Run the equilibrium MD simulation to sample vibrational modes
+#Here: 1GPU and 16 CPU cores are used --> see SBATCH flags: -G -c
+$gmx grompp -f sample-NPT.mdp -c ${inpGRO} -p ${inpTOP} -o sample-NPT.tpr >& grompp.out
+$gmx mdrun -v -deffnm sample-NPT -cpi >& mdrun.out
+
+#Start next part of the project if next=1
+if [ ${next} -eq 1 ]; then
+  if [ -f sample-NPT.gro ]; then
+    if [ -d ${nextDir} ]; then
+      curDir=`pwd`
+      cd ${nextDir}
+      if [ -f run.sh ]; then
+        sbatch run.sh
+      fi
+      cd ${curDir}
+    fi
+  fi
+fi

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/02-MD/sample-NPT.mdp
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/02-MD/sample-NPT.mdp
@@ -1,0 +1,44 @@
+; Run parameters
+integrator              = md        ; leap-frog integrator
+nsteps                  = 10000000  ; 2 * 10000000 = 20 ns
+dt                      = 0.002     ; 2 fs
+; Output control
+nstxout                 = 10        ; save coordinates every 20 fs
+nstvout                 = 10        ; save velocities every 20 fs
+nstenergy               = 500      ; save energies every 1 ps
+nstlog                  = 500      ; update log file every 1 ps
+; Center of mass (COM) motion
+nstcomm                 = 100       ; remove COM motion every 100 steps
+comm-mode               = Linear    ; remove only COM translation
+; Bond parameters
+continuation            = yes       ; first dynamics run
+constraint_algorithm    = lincs     ; holonomic constraints
+constraints             = h-bonds   ; constrain bonds with hydrogens
+lincs_iter              = 1         ; accuracy of LINCS
+lincs_order             = 4         ; also related to accuracy
+; Nonbonded settings
+cutoff-scheme           = Verlet    ; Buffered neighbor searching
+nstlist                 = 10        ; 10 fs, largely irrelevant with Verlet
+rcoulomb                = 1.0       ; short-range electrostatic cutoff (in nm)
+rvdw                    = 1.0       ; short-range van der Waals cutoff (in nm)
+DispCorr                = EnerPres  ; account for cut-off vdW scheme
+; Electrostatics
+coulombtype             = PME       ; Particle Mesh Ewald for long-range electrostatics
+pme_order               = 4         ; cubic interpolation
+fourierspacing          = 0.12      ; grid spacing for FFT
+; Temperature coupling is on
+tcoupl                  = Nose-Hoover       ; good for production, after equilibration
+; we define separate thermostats for the solute and solvent (need to adapt)
+; see default groups defined by Gromacs for your system or define your own (make_ndx)
+tc-grps                 = Protein  non-Protein  ; the separate groups for the thermostats
+tau-t                   = 1.0      1.0      ; time constants for thermostats (ps)
+ref-t                   = 300      300      ; reference temperature for thermostats (K)
+; Pressure coupling is off
+pcoupl                  = Parrinello-Rahman ; good for production, after equilibration
+tau-p                   = 2.0               ; time constant for barostat (ps)
+compressibility         = 4.5e-5            ; compressibility (1/bar) set to water at ~300K
+ref-p                   = 1.0               ; reference pressure for barostat (bar)
+; Periodic boundary conditions
+pbc                     = xyz       ; 3-D PBC
+; Velocity generation
+gen_vel                 = no

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/03-CG/clean.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/03-CG/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wd=`pwd`
+
+echo "This will delete your output data in ${wd}"
+read -p "Do you want to proceed? (y/n) " yn
+
+case $yn in 
+	y ) echo ok, we will proceed;;
+	n ) echo exiting...;
+		exit;;
+	* ) echo invalid response;
+		exit 1;;
+esac
+
+rm *.mtop mtop.out trjconv*.out coarse.inp coarse.out ref.gro ref.pdb ref-cg.gro *.trr slurm-*.out 

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/03-CG/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/03-CG/run.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+#SBATCH -p general
+#SBATCH -N 1
+#SBATCH -c 1
+#SBATCH -t 0-08:00                  # wall time (D-HH:MM)
+#SBATCH -J COARSE
+
+# FFTW is required
+
+#BEGIN INPUT
+gmx=gmx_plumed
+
+#GMX topology for protein
+inpTOPprot=../00-prep/topol_prot.top
+
+#GMX files from MD sampling
+inpTPR=../02-MD/sample-NPT.tpr
+inpTRR=../02-MD/sample-NPT.trr
+
+#output trajectory for protein with PBC fixes
+outTRRprotAA=../02-MD/sample-NPT_prot_pbc.trr
+
+#output trajectory for protein in CG representation
+outTRRprotCG=sample-NPT_prot_pbc-CG.trr
+
+#GMX group number for protein (gmx trjconv)
+outGrp=1
+
+#time between frames in input trajectory
+TRJtimestep=0.020
+
+#number of steps in input trajectory
+TRJframes=1000000
+next=1
+nextDir=../04-FRESEAN
+#END INPUT
+
+files=(
+${inpTOPprot}
+${inpTPR}
+${inpTRR}
+static.job
+)
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+#Generate a all-atom topology file (custom format) for the protein
+fresean mtop -p ${inpTOPprot} << STOP >& mtop.out
+${inpTOPprot}
+${inpTOPprot}
+topol_prot-aa.mtop
+STOP
+
+#Make the protein whole (fix PBC jumps) and write out protein-only trajectory
+$gmx trjconv -s ${inpTPR} -f ${inpTRR} -o ${outTRRprotAA} -pbc mol << STOP >& trjconv1.out
+${outGrp}
+STOP
+
+#Generate all-atom reference structure for rot+trans fitting
+$gmx trjconv -s ${inpTPR} -f ${outTRRprotAA} -o ref.gro -e 0.0 << STOP >& trjconv2.out
+${outGrp}
+STOP
+#some postprocessing for PLUMED compatibility of ref.pdb
+$gmx editconf -f ref.gro -o ref.pdb
+tail -n +5 ref.pdb > tmp.pdb
+head -n -2 tmp.pdb > ref.pdb
+sed -i '1i REMARK TYPE=OPTIMAL' ref.pdb
+sed -i '$aEND' ref.pdb
+rm tmp.pdb
+
+#Generate input parameter file for coarse-graining
+#WARNING: update expected soon
+cat << STOP >& coarse.inp
+#fnTop
+topol_prot-aa.mtop
+#fnCrd
+${outTRRprotAA}
+#fnVel (if format xyz,crd,dcd)
+#fnJob
+static.job
+#grp
+0
+#nRead
+${TRJframes}
+#analysisInterval
+1
+#fnOutTraj
+tmptraj.gro
+#fnOutTopol
+topol_prot-cg.mtop
+STOP
+#Apply coarse-graining to all-atom protein trajectory
+fresean coarse -f coarse.inp >& coarse.out
+#Convert coarse-grained trajectory from gro (ASCII text) to trr (binary) format
+$gmx trjconv -s tmptraj.gro -f tmptraj.gro -timestep ${TRJtimestep} -o ${outTRRprotCG} << STOP >& trjconv3.out
+0
+STOP
+
+#Generate coarse-grained reference structure for rot+trans fitting
+nAtoms=`head -n 2 tmptraj.gro | tail -n 1`
+nLines=${nAtoms}
+((nLines +=3))
+head -n ${nLines} tmptraj.gro >& ref-cg.gro
+rm tmptraj.gro
+
+#Start next part of the project if next=1
+if [ ${next} -eq 1 ]; then
+  if [ -f ${outTRRprotCG} ]; then
+    if [ -d ${nextDir} ]; then
+      curDir=`pwd`
+      cd ${nextDir}
+      if [ -f run.sh ]; then
+        sbatch run.sh
+      fi
+      cd ${curDir}
+    fi
+  fi
+fi

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/03-CG/static.job
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/03-CG/static.job
@@ -1,0 +1,16 @@
+#This is a job file describing
+#exclusively static groups.
+#
+[static_groups]         1
+# static group 0
+name                    all
+chain(s)                *
+residue(s)              *
+atom(s)                 *
+residue_number(s)       *
+residue_range           *
+atom_number(s)          *
+atom_range              *
+#
+[dynamic_groups]        0
+[combination_groups]    0

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/04-FRESEAN/clean.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/04-FRESEAN/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wd=`pwd`
+
+echo "This will delete your output data in ${wd}"
+read -p "Do you want to proceed? (y/n) " yn
+
+case $yn in
+        y ) echo ok, we will proceed;;
+        n ) echo exiting...;
+                exit;;
+        * ) echo invalid response;
+                exit 1;;
+esac
+
+rm *.mmat *mmat.dat *xyz covar.inp extract.inp *.out

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/04-FRESEAN/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/04-FRESEAN/run.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+#SBATCH -p htc
+#SBATCH -N 1
+#SBATCH -c 48
+#SBATCH -t 0-04:00                  # wall time (D-HH:MM)
+#SBATCH -J FRESEAN
+
+#FFTW is required
+
+#BEGIN INPUT
+
+#input topology in custom format
+inpMTOP=../03-CG/topol_prot-cg.mtop
+
+#input GMX trajectory file
+inpTRR=../03-CG/sample-NPT_prot_pbc-CG.trr
+
+#input reference file rot trans+rot fitting
+inpRefGROcg=../03-CG/ref-cg.gro
+
+#number of frames in trajectory
+nFrames=1000000
+
+#length of correlation functions in frames
+nCorr=100
+
+#stem name of output files
+outName=cg
+
+#trajectory time step (picoseconds)
+TRJtimestep=0.020
+next=1
+nextDir=../05-ModeProj
+#END INPUT
+
+files=(
+${inpMTOP}
+${inpTRR}
+${inpRefGROcg}
+static.job
+)
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+#Generate input parameter file for FRESEAN mode analysis
+cat << STOP >& covar.inp
+#fnTop (custom .mtop file)
+${inpMTOP}
+#fnCrd (CP2K position and velocity files)
+${inpTRR}
+#fnJob (Job file defining atom groups)
+static.job
+#nRead (Number of frames in the file)
+${nFrames}
+#analysisInterval (Analysis should be performed every X frames)
+1
+#fnRef (Reference file generated from genREF.exe)
+${inpRefGROcg}
+#alignGrp
+0
+#analyzeGrp
+0
+#wrap
+0
+#nCorr (correlation time in trajecotry steps)
+${nCorr}
+#winSigma (wavenumbers cm^-1)
+10.0
+#binaryMatrix
+1
+#doGenModes
+0
+#convergence (only for generalized normal modes)
+1.0e-5
+#maxIter (only for generalized normal modes)
+100
+#fnOut (Output file appender)
+${outName}
+STOP
+#Perform FRESEAN mode analysis for input trajectory
+#Here: we use 48 CPU cores --> see SBATCH flag: -c
+export OMP_NUM_THREADS=48
+fresean covar -f covar.inp >& covar.out
+
+#Diagonalize velocity cross correlation matrix at all sampled frequencies
+fresean eigen -m covar_${outName}.mmat -n $nCorr >& eigen.out
+
+#Generate input parameter file to extract FRESEAN modes sampled at zero frequency
+cat << STOP >& extract.inp
+#fnEigVec (file containing eigenvectors in binary format)
+evec_covar_${outName}.mmat
+#extractMode ( Mode 0 -> freqSel is in wavenumbers; Mode 1 -> freqSel is matrix index )
+1
+#freqSel (extract mode 0 -> Integer frequency in cm^-1;  mode 1 -> frequency index)
+1
+#trrFreq
+${TRJtimestep}
+#modeStart (First vibrational mode to read)
+1
+#modeEnd (Last vibrational mode to read)
+30
+#fnOut ( Output file appender )
+cg.xyz
+STOP
+#Extract zero frequency modes
+fresean extract -f extract.inp >& extract.out
+
+#Start next part of the project if next=1
+if [ ${next} -eq 1 ]; then
+  if [ -f evec_freq1_mode1-30_cg.xyz ]; then
+    if [ -d ${nextDir} ]; then
+      curDir=`pwd`
+      cd ${nextDir} 
+      if [ -f run.sh ]; then
+        sbatch run.sh
+      fi
+      cd ${curDir}
+    fi
+  fi
+fi

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/04-FRESEAN/static.job
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/04-FRESEAN/static.job
@@ -1,0 +1,16 @@
+#This is a job file describing
+#exclusively static groups.
+#
+[static_groups]         1
+# static group 0
+name                    all
+chain(s)                *
+residue(s)              *
+atom(s)                 *
+residue_number(s)       *
+residue_range           *
+atom_number(s)          *
+atom_range              *
+#
+[dynamic_groups]        0
+[combination_groups]    0

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/clean.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wd=`pwd`
+
+echo "This will delete your output data in ${wd}"
+read -p "Do you want to proceed? (y/n) " yn
+
+case $yn in
+        y ) echo ok, we will proceed;;
+        n ) echo exiting...;
+                exit;;
+        * ) echo invalid response;
+                exit 1;;
+esac
+
+rm plumed-mode-input.pdb *.out

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/plumed-mode-projection.dat
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/plumed-mode-projection.dat
@@ -1,0 +1,5 @@
+# Import the file containing the eigenvectors
+PCAVARS REFERENCE=plumed-mode-input.pdb TYPE=OPTIMAL LABEL=pca
+
+# Print the displacement projections (col 2 and 3) and all the other variables you want
+PRINT ARG=pca.eig-1,pca.eig-2 FILE=plumed-mode-projection.out STRIDE=1000

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/prep_plumed.py
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/prep_plumed.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python3
+
+import numpy as np
+import sys
+# Working directory where the reference pdb file can be found. Follow above steps.
+# This reference structure is already in pdb format.
+
+struct = np.loadtxt(f'ref.pdb', dtype=str, comments=['END', 'REMARK', 'TITLE', 'MODEL', 'TER', 'CRYST1'], usecols=[0,1,2,3,4,5,6,7])
+
+# Working directory where the modes are calculated from
+
+# Mode to convert to .pdb format
+mode = int(sys.argv[1])
+
+# Number of coarsened beads and array for eigenvector
+nBeads = 0
+
+# Index for selected eigenvector line (DO NOT CHANGE - SHOULD BE 0)
+curr = 0
+
+# Open the xyz eigenvector file and iterate through, storing the eigenvector for each
+# atom in the array
+with open(f'input-cg-modes.xyz','r') as file:
+
+    # Index for file line
+    counter = 0
+    for line in file:
+        if counter == 0:
+            nBeads = int(line)
+            eigvec = np.zeros((nBeads,3))
+        counter = counter + 1
+
+        # Skip the two line header and record the 1st through 3rd columns until you reach
+        # The next mode
+        if(counter > (nBeads+2)*(mode - 1)+2 and counter <= (nBeads+2)*(mode)):
+            eigvec[curr,:]=line.split()[1:4]
+            curr = curr + 1
+
+
+print(f"Number of beads: {nBeads}\nConverting Mode {mode}\n")
+# Some functions that we use to check if the current atom in the reference structure
+# 1. Is part of a residue only containing backbone atoms
+# 2. Is currently a backbone atom
+
+# This will have to be expanded to consider things like capping residues,
+# non-canonical AA's, etc.
+# But none of the current proteins we are analyzing have those.
+
+backboneAtoms = ["CA", "OC1", "OC2", "C", "O", "HA", "N", "H", "H1","H2","H3"]
+
+def isBackboneOnly(resName):
+    if(resName == "GLY"):
+        return True
+    else:
+        return False
+
+def inBackbone(atomName):
+    if atomName in backboneAtoms:
+        return True
+    else:
+        return False
+
+def calcSizes(struct, nBeads):
+    prevRes = int(struct[0,4]) # Resid of the first residue in pdb file
+    curr = 0
+    scaling = 100 # Constant to scale modes by
+    beadCounter = np.zeros(nBeads)
+    for i in range(len(struct)):
+
+        # Check to see if the current atom is in the same residue as the last atom
+        if(int(struct[i,4]) == prevRes):
+            # If it is, check to see if it is an atom with only backbone atoms
+            if(isBackboneOnly(struct[i,3])):
+                beadCounter[curr] = beadCounter[curr] + 1
+            
+            elif(not isBackboneOnly(struct[i,3])):
+                if(inBackbone(struct[i,2])):
+                    beadCounter[curr] = beadCounter[curr] + 1
+                elif(not inBackbone(struct[i,2])):
+                    beadCounter[curr+1] = beadCounter[curr+1] + 1
+
+        elif(int(struct[i,4]) != prevRes):
+            prevRes = int(struct[i,4])
+        
+            # If the last residue only contained backbone atoms, then we only need to iterate
+            # once. However, the the last residue had BACK and SIDE reßßßsidues, we need to iterate
+            # twice to move to the eigenvectors associated with the next residue.
+            if(isBackboneOnly(struct[i-1,3])):
+                curr = curr + 1
+            else:
+                curr = curr + 2
+            
+            # This is the same as the outermost if statement. This is required to handle the edge
+            # case of switching residues.
+            # Could probably be in a function.
+            if(isBackboneOnly(struct[i,3])):
+                beadCounter[curr] = beadCounter[curr] + 1
+            else:
+                if(int(struct[i,4]) == prevRes and inBackbone(struct[i,2])):
+                    beadCounter[curr] = beadCounter[curr] + 1
+                elif(int(struct[i,4]) == prevRes and not inBackbone(struct[i,2])):
+                    beadCounter[curr+1] = beadCounter[curr+1] + 1
+    return beadCounter
+# Now we will parse the reference structure and match our bead eigenvectors to the atoms
+
+prevRes = int(struct[0,4]) # Resid of the first residue in pdb file
+curr = 0
+scaling = 100 # Constant to scale modes by
+beadCounter = calcSizes(struct, nBeads)
+print(beadCounter, len(beadCounter))
+
+# For all atoms in the protein
+for i in range(len(struct)):
+
+    # Check to see if the current atom is in the same residue as the last atom
+    if(int(struct[i,4]) == prevRes):
+        
+        # If it is, check to see if it is an atom with only backbone atoms
+        if(isBackboneOnly(struct[i,3])):
+
+            # If it is backbone only, apply current coarsened eigenvector to the current atom
+            struct[i,5] = np.round(float(eigvec[curr,0]*scaling/beadCounter[curr]),3)
+            struct[i,6] = np.round(float(eigvec[curr,1]*scaling/beadCounter[curr]),3)
+            struct[i,7] = np.round(float(eigvec[curr,2]*scaling/beadCounter[curr]),3)
+            
+        # If it is NOT backbone only, we need to figure out if the current atom
+        # is a backbone atom or a sidechain atom
+        elif(not isBackboneOnly(struct[i,3])):
+            
+            # If it is a backbone atom, apply the current coarsened eigenvector to 
+            # current atom
+            if(inBackbone(struct[i,2])):
+                struct[i,5] = np.round(float(eigvec[curr,0]*scaling/beadCounter[curr]),3)
+                struct[i,6] = np.round(float(eigvec[curr,1]*scaling/beadCounter[curr]),3)
+                struct[i,7] = np.round(float(eigvec[curr,2]*scaling/beadCounter[curr]),3)
+                
+            # If it is a sidechain atom, we have to look at the next coarsened eigenvector
+            # Since our convention is BACK then SIDE
+            elif(not inBackbone(struct[i,2])):
+                struct[i,5] = np.round(float(eigvec[curr+1,0]*scaling/beadCounter[curr+1]),3)
+                struct[i,6] = np.round(float(eigvec[curr+1,1]*scaling/beadCounter[curr+1]),3)
+                struct[i,7] = np.round(float(eigvec[curr+1,2]*scaling/beadCounter[curr+1]),3)
+            
+    # If the current atom residue number is not equal to the residue number of the 
+    # previous atom, we need to get the eigenvectors for the next residue
+    elif(int(struct[i,4]) != prevRes):
+        
+        # The previous residue is going to be the residue of the current atom in the next
+        # iteration
+        prevRes = int(struct[i,4])
+        
+        # If the last residue only contained backbone atoms, then we only need to iterate
+        # once. However, the the last residue had BACK and SIDE residues, we need to iterate
+        # twice to move to the eigenvectors associated with the next residue.
+        if(isBackboneOnly(struct[i-1,3])):
+            curr = curr + 1
+        else:
+            curr = curr + 2
+            
+        # This is the same as the outermost if statement. This is required to handle the edge
+        # case of switching residues.
+        # Could probably be in a function.
+        if(isBackboneOnly(struct[i,3])):
+            struct[i,5] = np.round(float(eigvec[curr,0]*scaling/beadCounter[curr]),3)
+            struct[i,6] = np.round(float(eigvec[curr,1]*scaling/beadCounter[curr]),3)
+            struct[i,7] = np.round(float(eigvec[curr,2]*scaling/beadCounter[curr]),3)
+        else:
+            if(int(struct[i,4]) == prevRes and inBackbone(struct[i,2])):
+                struct[i,5] = np.round(float(eigvec[curr,0]*scaling/beadCounter[curr]),3)
+                struct[i,6] = np.round(float(eigvec[curr,1]*scaling/beadCounter[curr]),3)
+                struct[i,7] = np.round(float(eigvec[curr,2]*scaling/beadCounter[curr]),3)
+            elif(int(struct[i,4]) == prevRes and not inBackbone(struct[i,2])):
+                beadCounter[curr+1] = beadCounter[curr+1] + 1
+                struct[i,5] = np.round(float(eigvec[curr+1,0]*scaling/beadCounter[curr+1]),3)
+                struct[i,6] = np.round(float(eigvec[curr+1,1]*scaling/beadCounter[curr+1]),3)
+                struct[i,7] = np.round(float(eigvec[curr+1,2]*scaling/beadCounter[curr+1]),3)
+
+
+# Export the eigenvector
+with open(f"evec_{mode}_aa_scaled.pdb","w") as writer:
+    writer.write("REMARK TYPE=DIRECTION\n")
+    for line in struct:
+        writer.write(f'{line[0]}  {line[1]:>5} {line[2]:>4} {line[3]:1} {line[4]:>5}    {float(line[5]):8.3f}{float(line[6]):>8.3f}{float(line[7]):>8.3f}  1.00  0.00\n')
+    writer.write("END\n")
+writer.close()

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/run.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+#SBATCH -p general
+#SBATCH -N 1
+#SBATCH -c 1
+#SBATCH -t 0-01:00                  # wall time (D-HH:MM)
+#SBATCH -J PROJ
+
+# FFTW is required
+# Python3 with numpy is required
+
+############################
+# CHECK NUMPY INSTALLATION #
+############################
+
+contains_numpy=`pip list | awk 'BEGIN {i=0} $1 ~ "numpy" {i=1} END {print i}'`
+
+if [ ${contains_numpy} != 1 ];then
+echo "You are missing numpy."
+exit
+fi
+
+
+############################
+#        BEGIN INPUT       #
+############################
+
+#all-atom reference structure (must match CG reference)
+inpRefPDBaa=../03-CG/ref.pdb
+
+#coarse-grained zero-frequency eigenvectors
+inpModesXYZ=../04-FRESEAN/evec_freq1_mode1-30_cg.xyz
+
+# 20 ns unbiased trajectory
+inpTRR=../02-MD/sample-NPT_prot_pbc.trr
+
+# If next=1 -> start next step automatically
+# If next=0 -> terminate after this step
+next=1
+nextDir=../06-resample
+
+# If ERROR_FLAG=0 -> no error
+ERROR_FLAG=0
+
+############################
+#   CHECK FILE EXISTANCE   #
+############################
+
+files=(
+${inpRefPDBaa}
+${inpModesXYZ}
+prep_plumed.py
+plumed-mode-projection.dat
+)
+
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+###########################
+#  BEGIN MODE CONVERSION  #
+###########################
+
+cp ${inpRefPDBaa} ref.pdb
+cp ${inpModesXYZ} input-cg-modes.xyz
+
+# Convert FRESEAN modes 7 & 8 at zero frequency
+mode=7
+python prep_plumed.py $mode >& prep_plumed_mode${mode}.out
+mode=8
+python prep_plumed.py $mode >& prep_plumed_mode${mode}.out
+
+###########################
+#  CHECK PREP COMPLETION  #
+###########################
+
+reflinecount=`cat ref.pdb | awk 'BEGIN {natoms=0} $1 ~ "ATOM" || $1 ~ "HETATM" {natoms++} END {print natoms} '`
+mode7linecount=`cat evec_7_aa_scaled.pdb | awk 'BEGIN {natoms=0} $1 ~ "ATOM" || $1 ~ "HETATM" {natoms++} END {print natoms}'`
+mode8linecount=`cat evec_8_aa_scaled.pdb | awk 'BEGIN {natoms=0} $1 ~ "ATOM" || $1 ~ "HETATM" {natoms++} END {print natoms}'`
+echo "Found ${reflinecount} atoms in ref.pdb"
+echo "Found ${mode7linecount} atoms in evec_7_aa_scaled.pdb"
+echo "Found ${mode8linecount} atoms in evec_8_aa_scaled.pdb"
+
+if [ ${mode7linecount} != ${reflinecount} ]; then
+	echo "Mode 7 (evec_7_aa_scaled.pdb) is incomplete."
+	ERROR_FLAG=1
+fi
+
+if [ ${mode8linecount} != ${reflinecount} ]; then
+	echo "Mode 8 (evec_8_aa_scaled.pdb) is incomplete."
+	ERROR_FLAG=1
+fi
+
+if [ ${ERROR_FLAG} == 1 ];then
+	exit
+fi
+
+#Combine extracted modes with all-atom reference input PLUMED input
+cat ref.pdb evec_7_aa_scaled.pdb evec_8_aa_scaled.pdb > plumed-mode-input.pdb
+rm ref.pdb input-cg-modes.xyz evec_7_aa_scaled.pdb evec_8_aa_scaled.pdb
+
+#Analyze displacement fluctuations along FRESEAN modes
+plumed driver --mf_trr ${inpTRR} --plumed plumed-mode-projection.dat --kt 2.494339 > plumed-driver.out
+
+#number of histogram bins
+bins=200
+
+#print standard deviations of displacement fluctuations along FRSEAN modes
+python standard-deviation.py plumed-mode-projection.out $bins >& standard-deviation.out
+
+#Start next part of the project if next=1
+if [ ${next} -eq 1 ]; then
+  if [ -f plumed-mode-projection.dat ]; then
+    if [ -d ${nextDir} ]; then
+      curDir=`pwd`
+      cd ${nextDir}
+      if [ -f run.sh ]; then
+        sbatch run.sh
+      fi
+      cd ${curDir}
+    fi
+  fi
+fi

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/standard-deviation.py
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/05-ModeProj/standard-deviation.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+import sys
+
+# Variable to be set by the user
+import numpy as np
+import pandas as pd
+
+num_modes = 2 # Number of modes to read in
+
+
+projDispFile = str(sys.argv[1])
+pts=int(sys.argv[2])
+
+# Read in data and store in dataframe
+EIGVEC_D1 = np.zeros((num_modes,pts))
+EIGVEC_D1 = np.loadtxt(f'{projDispFile}', dtype=float, comments=['#'], usecols=[1,2])
+
+# Convert numpy array to pandas dataframe
+# Convert from Angstroms to nanometers
+EIGVEC_D1_df = pd.DataFrame(EIGVEC_D1, columns=["Mode 7", "Mode 8"])
+
+range_mode7 = np.std(EIGVEC_D1_df["Mode 7"])
+range_mode8 = np.std(EIGVEC_D1_df["Mode 8"])
+print(f"Standard Deviation of Mode 7 Displacement Projection: {range_mode7} nm")
+print(f"Standard Deviation of Mode 8 Displacement Projection: {range_mode8} nm")

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/06-resample/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/06-resample/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH -p general
+#SBATCH -G a100:1
+#SBATCH -N 1
+#SBATCH -c 16
+#SBATCH -t 0-12:00
+#SBATCH -J RESAMPLE
+
+# Working directory for where the topology and starting structure are
+workingDir=../..
+inpTOP=$workingDir/00-prep/topol.top
+inpGRO=$workingDir/01-em+equi/equi/equi.gro
+gmx=gmx_plumed
+
+# Create a new directory to run 100 ns unbiased MD
+mkdir run-NPT
+cd run-NPT
+$gmx grompp -f ../sample-states.mdp -c ${inpGRO} -p ${inpTOP} -o sample-states.tpr >& grompp.out
+$gmx mdrun -v -deffnm sample-states -cpi >& mdrun.out
+cd ..
+ 
+# Pull configuration every 5 ns
+mkdir snapshots
+$gmx trjconv -s run-NPT/sample-states.tpr -f run-NPT/sample-states.trr -pbc mol -sep -dt 5000.0 -ndec 8 -o snapshots/state_.gro <<END
+0
+END

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/06-resample/sample-states.mdp
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/06-resample/sample-states.mdp
@@ -1,0 +1,44 @@
+; Run parameters
+integrator              = md        ; leap-frog integrator
+nsteps                  = 50000000  ; 2 * 50000000 = 100 ns
+dt                      = 0.002     ; 2 fs
+; Output control
+nstxout                 = 100000    ; save coordinates every 200 ps
+nstvout                 = 100000    ; save velocities every 200 ps
+nstenergy               = 500000    ; save energies every 1 ns
+nstlog                  = 500000    ; update log file every 1 ns
+; Center of mass (COM) motion
+nstcomm                 = 100       ; remove COM motion every 100 steps
+comm-mode               = Linear    ; remove only COM translation
+; Bond parameters
+continuation            = yes       ; first dynamics run
+constraint_algorithm    = lincs     ; holonomic constraints
+constraints             = h-bonds   ; constrain bonds with hydrogens
+lincs_iter              = 1         ; accuracy of LINCS
+lincs_order             = 4         ; also related to accuracy
+; Nonbonded settings
+cutoff-scheme           = Verlet    ; Buffered neighbor searching
+nstlist                 = 10        ; 10 fs, largely irrelevant with Verlet
+rcoulomb                = 1.0       ; short-range electrostatic cutoff (in nm)
+rvdw                    = 1.0       ; short-range van der Waals cutoff (in nm)
+DispCorr                = EnerPres  ; account for cut-off vdW scheme
+; Electrostatics
+coulombtype             = PME       ; Particle Mesh Ewald for long-range electrostatics
+pme_order               = 4         ; cubic interpolation
+fourierspacing          = 0.12      ; grid spacing for FFT
+; Temperature coupling is on
+tcoupl                  = Nose-Hoover       ; good for production, after equilibration
+; we define separate thermostats for the solute and solvent (need to adapt)
+; see default groups defined by Gromacs for your system or define your own (make_ndx)
+tc-grps                 = Protein  non-Protein  ; the separate groups for the thermostats
+tau-t                   = 1.0      1.0      ; time constants for thermostats (ps)
+ref-t                   = 300      300      ; reference temperature for thermostats (K)
+; Pressure coupling is off
+pcoupl                  = Parrinello-Rahman ; good for production, after equilibration
+tau-p                   = 2.0               ; time constant for barostat (ps)
+compressibility         = 4.5e-5            ; compressibility (1/bar) set to water at ~300K
+ref-p                   = 1.0               ; reference pressure for barostat (bar)
+; Periodic boundary conditions
+pbc                     = xyz       ; 3-D PBC
+; Velocity generation
+gen_vel                 = no

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+nReplicas=20
+for (( i=0; i<${nReplicas}; i++ ))
+do
+cp -r single_metad metadyn_$i
+cd metadyn_$i
+echo "Run replica $i"
+sbatch --job-name=METAD_REPLICA_${i}.run --export=replica=${i} startme.sh
+cd ..
+done

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/clean.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wd=`pwd`
+
+echo "This will delete your output data in ${wd}"
+read -p "Do you want to proceed? (y/n) " yn
+
+case $yn in
+        y ) echo ok, we will proceed;;
+        n ) echo exiting...;
+                exit;;
+        * ) echo invalid response;
+                exit 1;;
+esac
+
+rm *.tpr *.trr *.edr *.log *.cpt *.out *.hills *.fes mdout.mdp plumed-mode-input.pdb

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/metadyn.mdp
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/metadyn.mdp
@@ -1,0 +1,44 @@
+; Run parameters
+integrator              = md        ; leap-frog integrator
+nsteps                  = 50000000  ; 2 * 50000000 = 100 ns
+dt                      = 0.002     ; 2 fs
+; Output control
+nstxout                 = 500      ; save coordinates every 5 ps
+nstvout                 = 500      ; save velocities every 5 ps
+nstenergy               = 500      ; save energies every 5 ps
+nstlog                  = 500      ; update log file every 5 ps
+; Center of mass (COM) motion
+nstcomm                 = 100       ; remove COM motion every 100 steps
+comm-mode               = Linear    ; remove only COM translation (liquids in PBC) 
+; Bond parameters
+continuation            = yes       ; first dynamics run
+constraint_algorithm    = lincs     ; holonomic constraints
+constraints             = h-bonds   ; all bonds lengths are constrained
+lincs_iter              = 1         ; accuracy of LINCS
+lincs_order             = 4         ; also related to accuracy
+; Nonbonded settings
+cutoff-scheme           = Verlet    ; Buffered neighbor searching
+nstlist                 = 10        ; 10 fs, largely irrelevant with Verlet
+rcoulomb                = 1.0       ; short-range electrostatic cutoff (in nm)
+rvdw                    = 1.0       ; short-range van der Waals cutoff (in nm)
+DispCorr                = EnerPres  ; account for cut-off vdW scheme
+; Electrostatics
+coulombtype             = PME       ; Particle Mesh Ewald for long-range electrostatics
+pme_order               = 4         ; cubic interpolation
+fourierspacing          = 0.12      ; grid spacing for FFT
+; Temperature coupling is on
+tcoupl                  = Nose-Hoover       ; good for production, after equilibration
+; we define separate thermostats for the solute and solvent (need to adapt)
+; see default groups defined by Gromacs for your system or define your own (make_ndx)
+tc-grps                 = Protein  non-Protein  ; the separate groups for the thermostats
+tau-t                   = 1.0      1.0      ; time constants for thermostats (ps)
+ref-t                   = 300      300      ; reference temperature for thermostats (K)
+; Pressure coupling is off
+pcoupl                  = Parrinello-Rahman ; good for production, after equilibration
+tau-p                   = 2.0               ; time constant for barostat (ps)
+compressibility         = 4.5e-5            ; compressibility (1/bar) set to water at ~300K
+ref-p                   = 1.0               ; reference pressure for barostat (bar)
+; Periodic boundary conditions
+pbc                     = xyz       ; 3-D PBC
+; Velocity generation
+gen_vel                 = no

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/plumed-mode-metadyn.dat
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/plumed-mode-metadyn.dat
@@ -1,0 +1,15 @@
+PCAVARS REFERENCE=plumed-mode-input.pdb TYPE=OPTIMAL LABEL=pca
+
+METAD ...
+LABEL=metad
+ARG=pca.eig-1,pca.eig-2
+PACE=500
+HEIGHT=0.1
+BIASFACTOR=10
+SIGMA=0.001,0.001
+FILE=plumed-mode-metadyn.hills
+TEMP=300.0
+... METAD
+
+# monitor the two variables and the metadynamics bias potential
+PRINT  ARG=pca.eig-1,pca.eig-2,pca.residual,metad.bias FILE=plumed-mode-metadyn.out STRIDE=500

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/startme.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/07-metadyn/single_metad/startme.sh
@@ -1,0 +1,69 @@
+#!/bin/bash                                                                     
+#SBATCH -p general
+#SBATCH -G a100:1
+#SBATCH -c 12
+#SBATCH -N 1
+#SBATCH -t 7-00:00
+#SBATCH -J METAD_0
+
+# FFTW IS REQUIRED (PLUMED)
+
+# Working directory containing starting topology
+workingDir=../..
+inpTOP=$workingDir/00-prep/topol.top
+gmx=gmx_plumed
+
+# Starting struct
+inpGRO=$workingDir/06-resample/snapshots/state_${replica}.gro
+
+# MetaD CV file
+inpPlumedPDB=$workingDir/05-ModeProj/plumed-mode-input.pdb
+#GMX group number for protein (gmx trjconv)
+outGrp=1
+#END INPUT
+
+files=(
+${inpTOP}
+${inpGRO}
+${inpPlumedPDB}
+metadyn.mdp
+plumed-mode-metadyn.dat
+)
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+#Copy PLUMED input file with reference structure and FRESEAN modes to standardized file name
+cp ${inpPlumedPDB} plumed-mode-input.pdb
+
+if [ ! -f metadyn.tpr ]; then
+#Create tpr input file for WT-metadynamics simulation
+$gmx grompp -f metadyn.mdp -c ${inpGRO} -p ${inpTOP} -o metadyn.tpr >& grompp.out
+fi
+
+if [ ! -f metadyn_prot.tpr ]; then
+#Create tpr file with only protein atoms for analysis
+$gmx convert-tpr -s metadyn.tpr -o metadyn_prot.tpr << STOP >& tpr-convert.out
+${outGrp}
+STOP
+fi
+
+#Run the WT-metadynamics simulation with GROMACS & PLUMED
+$gmx mdrun -v -deffnm metadyn -cpi -plumed plumed-mode-metadyn.dat >& mdrun.out
+
+# kT in kJ/mol can be determined by running `plumed kT --temp 300`
+kt=2.494339
+#Generate free energy surface in FRESEAN mode space
+plumed sum_hills --min -0.02,-0.02 --max 0.02,0.02 --bin 200,200 --hills plumed-mode-metadyn.hills --outfile plumed-mode-metadyn.fes --mintozero --kt 2.494339 --stride 5000
+
+#Write out metadynamics trajectory for only protein atoms after PBC fix
+$gmx trjconv -s metadyn.tpr -f metadyn.trr -o metadyn_prot_pbc.trr -pbc mol << STOP >& trjconv.out
+${outGrp}
+STOP
+
+rm metadyn.trr

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/plumed-mass+charge.dat
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/plumed-mass+charge.dat
@@ -1,0 +1,5 @@
+# Extract the charges and masses from a tpr file
+# Atom range should be from 1 to the total number of atoms in the tpr file
+
+protein: GROUP ATOMS=@mdatoms
+DUMPMASSCHARGE FILE=mass+charge.dat ATOMS=protein

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/plumed-reweight-CV.dat
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/plumed-reweight-CV.dat
@@ -1,0 +1,29 @@
+# Reference file containing eigenvectors
+PCAVARS REFERENCE=plumed-mode-input.pdb TYPE=OPTIMAL LABEL=pca
+
+# Go through metadynamics trajectory and get the weight every frame
+METAD ...
+LABEL=metad
+ARG=pca.eig-1,pca.eig-2
+PACE=10000
+HEIGHT=0.0
+BIASFACTOR=10
+SIGMA=0.001,0.001
+FILE=plumed-mode-metadyn.hills
+TEMP=300.0
+RESTART=YES
+... METAD
+
+# Index file with only c alpha atoms. Use to calculate Rg.
+CA: GROUP NDX_FILE=groups.ndx NDX_GROUP=C-alpha
+rg: GYRATION TYPE=RADIUS ATOMS=CA
+
+# Define the pincer angle.
+G1: COM ATOMS=422-480,1639-1724
+G2: COM ATOMS=1347-1397
+G3: COM ATOMS=663-700,759-784
+pincerangle: ANGLE ATOMS=G1,G2,G3
+
+# Print each of the desired quantities to a file. Can manually reweight.
+# Weight of frame i is given by w_i \propto exp(V/kT). V is given in the reweight file as metad.bias.
+PRINT ARG=pca.eig-1,pca.eig-2,pincerangle,rg,pca.residual,metad.bias FILE=plumed-reweight-CV.out STRIDE=1

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+nReplicas=20
+for (( i=0; i<${nReplicas}; i++ ))
+do
+cp -r single_rw reweight_$i
+cd reweight_$i
+echo "Run replica $i"
+sbatch --job-name=REWEIGHT_REPLICA_${i}.run --export=replica=${i} startme.sh
+cd ..
+done

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/single_rw/startme.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/08-reweight/single_rw/startme.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#SBATCH -p lightwork
+#SBATCH -q public
+#SBATCH -c 1
+#SBATCH -N 1
+#SBATCH -t 0-00:30
+#SBATCH -J REWEIGHT_0
+
+#BEGIN INPUT
+
+gmx=gmx_plumed
+#GMX topology for protein
+workingDir=../..
+i=${replica}
+inpTPRprot=$workingDir/07-metadyn/metadyn_$i/metadyn_prot.tpr
+inpTRRprot=$workingDir/07-metadyn/metadyn_$i/metadyn_prot_pbc.trr
+inpPlumedPDB=$workingDir/05-ModeProj/plumed-mode-input.pdb
+inpPlumedHills=$workingDir/07-metadyn/metadyn_$i/plumed-mode-metadyn.hills
+
+echo "Input TPR $inpTPRprot"
+echo "Input TRR $inpTRRprot"
+#END INPUT
+
+files=(
+${inpTPRprot}
+${inpTRRprot}
+)
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+#Copy PLUMED input file with reference structure and FRESEAN modes to standardized file name
+cp ${inpPlumedPDB} plumed-mode-input.pdb
+#Copy PLUMED hills file from metadynamics run as input for reweighting
+cp ${inpPlumedHills} plumed-mode-metadyn.hills
+
+$gmx mdrun -s ${inpTPRprot} -nsteps 1 -plumed ../plumed-mass+charge.dat >& plumed-mc.out
+
+# kT in kJ/mol can be determined by running `plumed kT --temp 300`
+kt=2.494339
+
+#Generate groups.ndx file from metadynamics gro output
+echo -e "a CA\nname 13 C-alpha\nq" | gmx make_ndx -f confout.gro -o groups.ndx >& make-ndx.out
+
+#Generate reweighted histogram as a function of new CVs
+plumed driver --mf_trr ${inpTRRprot} --plumed ../plumed-reweight-CV.dat --kt $kt --mc mass+charge.dat > reweight.out

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/09_average_structure_for_each_replica/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/09_average_structure_for_each_replica/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+nReplicas=20
+path=..
+reweightFilename=REWEIGHT-distances
+# For each replica
+for ((j=0;j<nReplicas;j++))
+do
+
+# Copy the template directory to template_pdb_replicaNumber
+cp -r template_pdb template_pdb_$j
+
+# DO NOT USE SED TO MODIFY SBATCH .SH SCRIPT JUST USE BUILT-IN EXPORTS
+
+# Generate the average structure for each replica in parallel
+cd template_pdb_$j
+sbatch --job-name=avg$j.run --output=avg$j.out --export=path=$path,replica=$j,rwFname=$reweightFilename run_generate_weighted_average_structure.sh
+cd ..
+done

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/09_average_structure_for_each_replica/template_pdb/generate_weighted_average_structure.py
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/09_average_structure_for_each_replica/template_pdb/generate_weighted_average_structure.py
@@ -1,0 +1,56 @@
+# Header
+#  
+# In this code we will generate the weighted average structure from
+# a provided WT- metadynamics trajectory (07-metadyn/) and weights (08-reweight/). 
+#
+
+import MDAnalysis as mda
+import numpy as np
+import math
+import argparse
+
+#Parse arguments for reference pdb and the trajectory
+parser = argparse.ArgumentParser()
+parser.add_argument("-ref", "--reference", type=str, required=True)
+parser.add_argument("-trr", "--trajectory", type=str, required=True)
+parser.add_argument("-cv", "--colvar", type=str, required=True)
+parser.add_argument("-o", "--output", type=str, required=True)
+args = parser.parse_args()
+
+reference_pdb = args.reference
+trajectory = args.trajectory
+colvar_file = args.colvar
+output_file = args.output
+
+# Import trajectory
+u = mda.Universe(reference_pdb, trajectory)
+
+# All atoms are used to compute average structure
+ag = u.select_atoms("all")
+num_frames = u.trajectory.n_frames 
+nAtoms = len(ag) # Number of atoms
+
+# Empty array used to store final structure
+average_position = np.zeros((nAtoms, 3))
+
+# Parameters
+bKT=2.5 
+wf=10e25 #Rescaling 
+skip=10 # Compute every 10 frames
+
+
+# Weights are extracted from the final column in the reweight file
+wk = np.exp(np.loadtxt(colvar_file, comments="#")[::skip,-1]/bKT)/wf
+wt = np.sum(wk)
+
+# For each frame in the trajectory
+for frame in u.trajectory[::skip]:
+    current_frame_idx = int(frame.frame/skip) # Get the current timestep index
+
+    # Add to the average position
+    average_position = average_position + wk[current_frame_idx]*ag.positions
+
+# Write the final weighted average structure in pdb format
+with open(f"{output_file}","w") as file:
+    for i in range(nAtoms):
+        file.write(f"{format(average_position[i,0], '.4f')}\t{format(average_position[i,1], '.4f')}\t{format(average_position[i,2], '.4f')}\t{format(wt, '.4f')}\n")

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/09_average_structure_for_each_replica/template_pdb/run_generate_weighted_average_structure.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/09_average_structure_for_each_replica/template_pdb/run_generate_weighted_average_structure.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#SBATCH -p htc
+#SBATCH -q public
+#SBATCH -c 1
+#SBATCH -N 1
+#SBATCH -t 0-00:30                  # wall time (D-HH:MM)                       
+#SBATCH -J DCCM_STEP1_0
+
+# Module Loading
+module load mamba/latest
+source activate KEMP_ML
+
+# Constants
+gmx=gmx_plumed
+outGrp=1 #protein
+
+# Input Variables from SBATCH command
+replica_id=$replica
+workingDir=$path
+reweightFilename=$rwFname
+
+# Input Variables
+inpTPRprot=$workingDir/07-metadyn/metadyn_0/metadyn_prot.tpr
+inpTRRprot=$workingDir/07-metadyn/metadyn_$replica_id/metadyn_prot_pbc.trr
+inpRefPDB=$workingDir/03-CG/ref.pdb 
+rw_file=$workingDir/08-reweight/reweight_$replica_id/$reweightFilename
+
+echo "Input TPR $inpTPRprot"
+echo "Input TRR $inpTRRprot"
+echo "Input Reference PDB $inpRefPDB"
+echo "Input Reweight Filepath $rw_file"
+
+#END INPUT
+
+files=(
+${inpTPRprot}
+${inpTRRprot}
+${inpRefPDB}
+${rw_file}
+)
+
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+# Generate protein trajectory fit to reference pdb
+$gmx trjconv -s ${inpRefPDB} -f ${inpTRRprot} -o metadyn_prot_fitted.xtc -fit rot+trans << STOP >& trjconv.out
+${outGrp}
+${outGrp}
+STOP
+
+# Generate the weighted average structure
+python3 generate_weighted_average_structure.py -ref $inpRefPDB -trr metadyn_prot_fitted.xtc -cv ${rw_file} -o average-test.dat >& average.out
+
+# Deactivate python enviornment
+source deactivate

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/10_average_structure_for_all_replicas/AVERAGE-weighted-pdb.f90
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/10_average_structure_for_all_replicas/AVERAGE-weighted-pdb.f90
@@ -1,0 +1,72 @@
+program AVRG
+integer::ounit
+real(kind=8),dimension(5000):: x1,y1,z1,w1
+real(kind=8):: x,y,z,w
+character(len=100),dimension(25)::datafile
+character(len=100):: outfile
+logical:: there,ANS
+data inunit,ounit /11,12/
+
+!---------------------------------------------
+write(*,'(1x,a)')'Enter the name of output file'
+read(*,'(a)')outfile
+write(*,*)outfile
+open(ounit,file=outfile,status='unknown',form='formatted',iostat=ios)
+!------------------------------------------------
+
+write(*,'(1x,a)') 'Enter first and last atom number '
+read(*,*)ifr,ilr
+write(*,*)ifr,ilr
+nres=ilr-ifr+1
+write(*,*)'total number of res',nres
+
+!write(*,'(1x,a)')'Enter the number of frames in each file'
+!read(*,*) nframes
+!write(*,*)'# of frames',nframes
+
+write(*,'(1x,a)')'Enter the number of data file'
+read(*,*)ndata
+
+write(*,*)'# of data files',ndata
+
+do inp=1,ndata
+write(*,'(1x,a,i5,a)')'Enter name of data file',inp
+read(*,'(a)')datafile(inp)
+write(*,*)datafile(inp)
+inquire(file=datafile(inp),exist=there)
+if(.not.there)then
+write(*,'(a)')'ERROR: INP FILE NOT FOUND'
+stop
+endif
+enddo
+
+do i=1,nres
+x1(i)=0.0
+y1(i)=0.0
+z1(i)=0.0
+w1(i)=0.0
+enddo
+
+do inp=1,ndata
+write(*,'(1x,a,i5,a)')'Enter name of data file',inp
+write(*,*)datafile(inp)
+open(inunit,file=datafile(inp),status='old')
+do i=1,nres
+read(inunit,*)x,y,z,w
+x1(i)=x1(i)+x
+y1(i)=y1(i)+y
+z1(i)=z1(i)+z
+w1(i)=w1(i)+w
+enddo
+enddo
+
+
+do i=1,nres
+x1(i)=x1(i)/w1(i)
+y1(i)=y1(i)/w1(i)
+z1(i)=z1(i)/w1(i)
+write(ounit,222)x1(i),y1(i),z1(i)
+enddo
+222 format (3f8.3)
+end
+

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/10_average_structure_for_all_replicas/f95_to_pdb.py
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/10_average_structure_for_all_replicas/f95_to_pdb.py
@@ -1,0 +1,34 @@
+import MDAnalysis as mda
+import numpy as np
+import math
+import argparse
+
+def read_coordinate_data(coordinate_file):
+    coordinates = np.loadtxt(coordinate_file) 
+    return coordinates
+
+#Parse arguments for reference pdb and the trajectory
+parser = argparse.ArgumentParser()
+parser.add_argument("-ref", "--reference", type=str, required=True)
+parser.add_argument("-x", "--coordinates", type=str, required=True)
+parser.add_argument("-o", "--output", type=str, required=True)
+args = parser.parse_args()
+
+reference_pdb_file = args.reference
+coordinate_file = args.coordinates
+output_pdb_file = args.output
+
+# Universe with pdb file
+z = mda.Universe(reference_pdb_file)
+
+# Coordinates are read from AVERAGE-weighted-pdb.f90 output
+coordinates = read_coordinate_data(coordinate_file)
+
+# PDB atoms
+selected_atoms = z.atoms
+
+# Replace the positions of the atoms in the pdb file with the atoms from the f90 average structure
+selected_atoms.positions = coordinates
+
+# Write out universe with correct atoms
+selected_atoms.write(output_pdb_file)

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/10_average_structure_for_all_replicas/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/10_average_structure_for_all_replicas/run.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#SBATCH -p htc
+#SBATCH -c 1
+#SBATCH -N 1
+#SBATCH -t 0-00:30                  # wall time (D-HH:MM)
+#SBATCH -J REWEIGHT
+
+# Load python enviornment
+module load mamba/latest
+source activate KEMP_ML
+
+# Input variables
+nReplicas=20
+path=.. 
+inpRefPDB=$path/03-CG/ref.pdb
+individual_average_directory=../09_average_structure_for_each_replica
+nAtoms=$(( $(wc -l ${inpRefPDB} | awk '{print $1}') - 2 ))
+inpWeightedAverageStruct=average-test.dat
+outWeightedAverageStruct=average_structure.dat
+
+# Compile f90 code with gfortran
+# NOTE: Move .f90 code to separate dir? Compile in make?
+gfortran AVERAGE-weighted-pdb.f90 -o AVERAGE-weighted-pdb.out
+
+cat << STOP >& average-reweight-pdb.inp
+${outWeightedAverageStruct}
+1 ${nAtoms}
+${nReplicas}
+${individual_average_directory}/template_pdb_0/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_1/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_2/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_3/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_4/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_5/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_6/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_7/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_8/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_9/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_10/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_11/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_12/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_13/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_14/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_15/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_16/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_17/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_18/${inpWeightedAverageStruct}
+${individual_average_directory}/template_pdb_19/${inpWeightedAverageStruct}
+STOP
+
+# Execute compiled code with provided input file
+./AVERAGE-weighted-pdb.out <average-reweight-pdb.inp >& ensemble.out
+
+python3 f95_to_pdb.py  -ref $inpRefPDB -x average_structure.dat -o ensemble_structure.pdb >& f95_to_pdb.out
+
+source deactivate

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/11_dcc_matrix_for_each_replica/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/11_dcc_matrix_for_each_replica/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+nReplicas=20
+path=..
+reweightFilename=REWEIGHT-distances
+
+for ((j=0;j<$nReplicas;j++))
+do
+
+cp -r template_dccm template_dccm_$j
+cd template_dccm_$j
+sbatch --job-name=dccm$j.run --output=dccm$j.out --export=path=$path,replica=$j,rwFname=$reweightFilename run.sh
+cd ..
+done

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/11_dcc_matrix_for_each_replica/template_dccm/dccm_reweight.py
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/11_dcc_matrix_for_each_replica/template_dccm/dccm_reweight.py
@@ -1,0 +1,77 @@
+import MDAnalysis as mda
+import numpy as np
+import math
+import argparse
+
+#Parse arguments for reference pdb and the trajectory
+parser = argparse.ArgumentParser()
+parser.add_argument("-ref", "--reference", type=str, required=True)
+parser.add_argument("-trr", "--trajectory", type=str, required=True)
+parser.add_argument("-cv", "--colvar", type=str, required=True)
+parser.add_argument("-av", "--average_structure", type=str, required=True)
+parser.add_argument("-o", "--output", type=str, required=True)
+args = parser.parse_args()
+
+reference_pdb = args.reference
+trajectory = args.trajectory
+colvar_file = args.colvar
+avg_struct = args.average_structure
+output_file = args.output
+
+
+trajectory_universe = mda.Universe(reference_pdb, trajectory)
+
+ag = trajectory_universe.select_atoms("name CA")
+ca = trajectory_universe.select_atoms('name CA')
+num_frames = trajectory_universe.trajectory.n_frames
+n_ca= len(ca)
+
+# Get the average structure
+average_universe = mda.Universe(avg_struct)
+alpha_carbons = average_universe.select_atoms("name CA")
+av = alpha_carbons.positions
+
+
+
+bKT=2.5
+wf=10e15
+skip=10
+nSteps=100001
+
+wk = np.exp(np.loadtxt(colvar_file, comments="#")[::skip, -1]/bKT)/wf
+wt = np.sum(wk)
+
+cor_xy=np.zeros((n_ca, n_ca))
+cor_x=np.zeros((n_ca, n_ca))
+cor_y=np.zeros((n_ca, n_ca))
+
+coords=np.zeros((num_frames, n_ca, 3))
+
+for frame in trajectory_universe.trajectory[::skip]:
+    current_frame_idx = int(frame.frame/skip)
+    coords[current_frame_idx] = ag.positions
+    for residue_x in range(n_ca - 1):
+        for residue_y in range(residue_x+1, n_ca):
+
+            di = coords[current_frame_idx, residue_x] - av[residue_x]
+            dj = coords[current_frame_idx, residue_y] - av[residue_y]
+
+            cor_xy[residue_x, residue_y] = cor_xy[residue_x, residue_y] + wk[current_frame_idx] * (di[0]*dj[0] + di[1]*dj[1]+ di[2]*dj[2])
+            cor_xy[residue_y, residue_x] = cor_xy[residue_x, residue_y]
+
+            cor_x[residue_x, residue_y] = cor_x[residue_x, residue_y] + wk[current_frame_idx] * (di[0]**2 + di[1]**2 + di[2]**2)
+            cor_x[residue_y, residue_x] = cor_x[residue_x, residue_y]
+
+            cor_y[residue_x, residue_y] = cor_y[residue_x, residue_y] + wk[current_frame_idx] * (dj[0]**2 + dj[1]**2 + dj[2]**2)
+            cor_y[residue_y, residue_x] = cor_y[residue_x, residue_y]
+           
+
+with open(output_file,"w") as file:
+    for residue_x in range(n_ca):
+        for residue_y in range(n_ca):
+            if residue_x == residue_y: 
+                cor_xy[residue_x, residue_y]=1.0
+            else:
+                cor_xy[residue_x, residue_y]=cor_xy[residue_x, residue_y]/((np.sqrt(cor_x[residue_x, residue_y]))*(np.sqrt(cor_y[residue_x, residue_y])))
+            file.write(f"{residue_x+1}\t{residue_y+1}\t{cor_xy[residue_x, residue_y]}\n")
+        file.write("\n")

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/11_dcc_matrix_for_each_replica/template_dccm/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/11_dcc_matrix_for_each_replica/template_dccm/run.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH -p general
+#SBATCH -q public
+#SBATCH -c 1
+#SBATCH -N 1
+#SBATCH -t 0-04:00                  # wall time (D-HH:MM)                       
+#SBATCH -J REWEIGHT_REPLICA_0
+
+# Module Loading
+module load mamba/latest
+source activate KEMP_ML
+
+# Constants
+gmx=gmx_plumed
+outGrp=1 #protein
+
+
+# Input Variables from SBATCH command
+replica_id=$replica
+workingDir=$path
+reweightFilename=$rwFname
+
+inpRefPDB=$workingDir/03-CG/ref.pdb
+rw_file=$workingDir/08-reweight/reweight_$replica_id/$reweightFilename
+
+weighted_average_structure=../../10_average_structure_for_all_replicas/ensemble_structure.pdb
+inpXTCprot=../../09_average_structure_for_each_replica/template_pdb_$replica_id/metadyn_prot_fitted.xtc
+
+echo "Input weighted_average_structure $weighted_average_structure"
+echo "Input XTC $inpXTCprot"
+#END INPUT
+
+files=(
+${weighted_average_structure}
+${inpTRRprot}
+)
+for file in ${files[@]}
+do
+if [ ! -f ${file} ]; then
+echo "-could not find file ${file} in current directory"
+echo "-exiting"
+exit
+fi
+done
+
+# Fit the trajectory to the weighted average structure
+$gmx trjconv -s ${weighted_average_structure} -f ${inpXTCprot} -o metadyn_prot_fit_to_avg.xtc -fit rot+trans << STOP >& trjconv.out
+${outGrp}
+${outGrp}
+STOP
+
+python3 dccm_reweight.py -ref $inpRefPDB -trr metadyn_prot_fit_to_avg.xtc -cv ${rw_file} -av $weighted_average_structure -o dccm.dat >& dccm.out
+
+source deactivate

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/12_dcc_matrix_for_all_replicas/AVERAGE-dccm.f90
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/12_dcc_matrix_for_all_replicas/AVERAGE-dccm.f90
@@ -1,0 +1,70 @@
+program AVRG
+integer::ounit
+real,dimension(300,300):: dccm
+character(len=100),dimension(25)::datafile
+character(len=100):: outfile
+logical:: there,ANS
+data inunit,ounit /11,12/
+
+!---------------------------------------------
+write(*,'(1x,a)')'Enter the name of output file'
+read(*,'(a)')outfile
+write(*,*)outfile
+open(ounit,file=outfile,status='unknown',form='formatted',iostat=ios)
+!------------------------------------------------
+
+write(*,'(1x,a)') 'Enter first and last res number '
+read(*,*)ifr,ilr
+write(*,*)ifr,ilr
+nres=ilr-ifr+1
+write(*,*)'total number of res',nres
+
+!write(*,'(1x,a)')'Enter the number of frames in each file'
+!read(*,*) nframes
+!write(*,*)'# of frames',nframes
+
+write(*,'(1x,a)')'Enter the number of data file'
+read(*,*)ndata
+
+write(*,*)'# of data files',ndata
+
+do inp=1,ndata
+write(*,'(1x,a,i5,a)')'Enter name of data file',inp
+read(*,'(a)')datafile(inp)
+write(*,*)datafile(inp)
+inquire(file=datafile(inp),exist=there)
+if(.not.there)then
+write(*,'(a)')'ERROR: INP FILE NOT FOUND'
+stop
+endif
+enddo
+do i=1,nres
+do j=1,nres
+dccm(i,j)=0.0
+enddo
+enddo
+
+do inp=1,ndata
+write(*,'(1x,a,i5,a)')'Enter name of data file',inp
+write(*,*)datafile(inp)
+open(inunit,file=datafile(inp),status='old')
+do i=1,nres
+do j=1,nres
+read(inunit,*)irj,irk,dcc
+dccm(i,j)=dccm(i,j)+dcc
+enddo
+read(inunit,*)
+enddo
+enddo
+
+
+do i=1,nres
+do j=1,nres
+dccm(i,j)=dccm(i,j)/ndata
+write(ounit,111)i,j,dccm(i,j)
+111 format(i4,i4,f10.4)
+enddo
+write(ounit,*)
+enddo
+end
+

--- a/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/12_dcc_matrix_for_all_replicas/run.sh
+++ b/scripts/protocol_FRESEAN+convergedWTMetad+DCCM/12_dcc_matrix_for_all_replicas/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#SBATCH -p htc
+#SBATCH -c 1
+#SBATCH -N 1
+#SBATCH -t 0-00:30                  # wall time (D-HH:MM)
+#SBATCH -J REWEIGHT
+
+# Input variables
+nReplicas=20
+path=.. 
+inpRefPDB=$path/03-CG/ref.pdb
+individual_average_directory=../11_dcc_matrix_for_each_replica
+nCA=$(awk '$3 == "CA" { count++ } END { print count }' $inpRefPDB)
+inpDCCM=dccm.dat
+outDCCM=dccm-reweight.dat
+
+# Compile f90 code with gfortran
+# NOTE: Move .f90 code to separate dir? Compile in make?
+gfortran AVERAGE-dccm.f90 -o AVERAGE-dccm.out
+
+cat << STOP >& average-dccm.inp
+${outDCCM}
+1 ${nCA}
+${nReplicas}
+${individual_average_directory}/template_dccm_0/${inpDCCM}
+${individual_average_directory}/template_dccm_1/${inpDCCM}
+${individual_average_directory}/template_dccm_2/${inpDCCM}
+${individual_average_directory}/template_dccm_3/${inpDCCM}
+${individual_average_directory}/template_dccm_4/${inpDCCM}
+${individual_average_directory}/template_dccm_5/${inpDCCM}
+${individual_average_directory}/template_dccm_6/${inpDCCM}
+${individual_average_directory}/template_dccm_7/${inpDCCM}
+${individual_average_directory}/template_dccm_8/${inpDCCM}
+${individual_average_directory}/template_dccm_9/${inpDCCM}
+${individual_average_directory}/template_dccm_10/${inpDCCM}
+${individual_average_directory}/template_dccm_11/${inpDCCM}
+${individual_average_directory}/template_dccm_12/${inpDCCM}
+${individual_average_directory}/template_dccm_13/${inpDCCM}
+${individual_average_directory}/template_dccm_14/${inpDCCM}
+${individual_average_directory}/template_dccm_15/${inpDCCM}
+${individual_average_directory}/template_dccm_16/${inpDCCM}
+${individual_average_directory}/template_dccm_17/${inpDCCM}
+${individual_average_directory}/template_dccm_18/${inpDCCM}
+${individual_average_directory}/template_dccm_19/${inpDCCM}
+STOP
+
+# Execute compiled code with provided input file
+./AVERAGE-dccm.out <average-dccm.inp >& average-dccm-driver.out


### PR DESCRIPTION
I am adding the DCCM protocol to the FRESEAN repository at `scripts/protocol_FRESEAN+convergedWTMetad+DCCM`. The DCCM protocol consists of the following directories.

- 09_average_structure_for_each_replica (Generate a weighted average structure for each WT-metadynamics replica)
- 10_average_structure_for_all_replicas (Generate the weighted average structure over ALL WT-metadynamics replicas)
- 11_dcc_matrix_for_each_replica (Generate the DCC matrix for each WT-metadynamics replica)
- 12_dcc_matrix_for_all_replicas (Generate the DCC matrix over ALL WT-metadynamics replicas)

